### PR TITLE
add a unified symbol representation for cross-language symbol graphs

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Relationship.swift
+++ b/Sources/SymbolKit/SymbolGraph/Relationship.swift
@@ -109,7 +109,7 @@ extension SymbolGraph {
 
 extension SymbolGraph.Relationship {
     /// The kind of relationship.
-    public struct Kind: Codable, RawRepresentable, Equatable {
+    public struct Kind: Codable, RawRepresentable, Equatable, Hashable {
         public var rawValue: String
         public init(rawValue: String) {
             self.rawValue = rawValue

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -240,28 +240,196 @@ extension SymbolGraph.Symbol {
 }
 
 extension SymbolGraph.Symbol {
-    /**
-     A description of a symbol's kind, such as a structure in C, or a protocol in Swift.
-     */
+    /// A description of a symbol's kind, such as a structure or protocol.
     public struct Kind: Equatable, Codable {
-        /**
-         A namespaced, unique identifier for a kind of symbol.
+        /// A unique identifier for this symbol's kind.
+        public var identifier: KindIdentifier
 
-         For example, a Swift class might use `"swift.class"`.
-         */
-        public var identifier: String
-        /**
-         A display name for a kind of symbol.
-
-         For example, a Swift class might use `"Class"`.
-         This display name should not be abbreviated:
-         for instance, use `"Structure"` instead of `"Struct"` if applicable.
-         */
+        /// A display name for a kind of symbol.
+        ///
+        /// For example, a Swift class might use `"Class"`.
+        /// This display name should not be abbreviated:
+        /// for instance, use `"Structure"` instead of `"Struct"` if applicable.
         public var displayName: String
 
-        public init(identifier: String, displayName: String) {
-            self.identifier = identifier
+        /// Initializes a new ``SymbolGraph/Symbol/Kind-swift.struct`` with an already-parsed
+        /// ``SymbolGraph/Symbol/KindIdentifier`` and display name.
+        public init(parsedIdentifier: KindIdentifier, displayName: String) {
+            self.identifier = parsedIdentifier
             self.displayName = displayName
+        }
+
+        /// Initializes a new ``SymbolGraph/Symbol/Kind-swift.struct`` by parsing a new
+        /// ``SymbolGraph/Symbol/KindIdentifier`` from the given identifier string, and combining it
+        /// with a display name.
+        @available(*, deprecated, message: "Use init(rawIdentifier:displayName:) instead")
+        public init(identifier: String, displayName: String) {
+            self.init(rawIdentifier: identifier, displayName: displayName)
+        }
+
+        /// Initializes a new ``SymbolGraph/Symbol/Kind-swift.struct`` by parsing a new
+        /// ``SymbolGraph/Symbol/KindIdentifier`` from the given identifier string, and combining it
+        /// with a display name.
+        public init(rawIdentifier: String, displayName: String) {
+            self.identifier = KindIdentifier(identifier: rawIdentifier)
+            self.displayName = displayName
+        }
+    }
+}
+
+extension SymbolGraph.Symbol {
+    /**
+     A unique identifier of a symbol's kind, such as a structure or protocol.
+     */
+    public enum KindIdentifier: Equatable, Hashable, Codable, CaseIterable {
+        case `associatedtype`
+        case `class`
+        case `deinit`
+        case `enum`
+        case `case`
+        case `func`
+        case `operator`
+        case `init`
+        case `method`
+        case `property`
+        case `protocol`
+        case `struct`
+        case `subscript`
+        case `typeMethod`
+        case `typeProperty`
+        case `typeSubscript`
+        case `typealias`
+        case `var`
+
+        case `module`
+        
+        case `unknown`
+        
+        
+        /// A string that uniquely identifies the symbol kind.
+        ///
+        /// If the original kind string was not recognized, this will return `"unknown"`.
+        public var identifier: String {
+            get {
+                switch self {
+                case .associatedtype : return "associatedtype"
+                case .class          : return "class"
+                case .deinit         : return "deinit"
+                case .enum           : return "enum"
+                case .case           : return "enum.case"
+                case .func           : return "func"
+                case .operator       : return "func.op"
+                case .`init`         : return "init"
+                case .method         : return "method"
+                case .property       : return "property"
+                case .protocol       : return "protocol"
+                case .struct         : return "struct"
+                case .subscript      : return "subscript"
+                case .typeMethod     : return "type.method"
+                case .typeProperty   : return "type.property"
+                case .typeSubscript  : return "type.subscript"
+                case .typealias      : return "typealias"
+                case .var            : return "var"
+                case .module         : return "module"
+                case .unknown        : return "unknown"
+                }
+            }
+        }
+
+        // FIXME: Save "unknown" symbol kinds in a synchronized set to prevent loss of data (rdar://84276085)
+
+        /// Check the given identifier string against the list of known identifiers.
+        ///
+        /// - Parameter identifier: The identifier string to check.
+        /// - Returns: The matching `KindIdentifier` case, or `nil` if there was no match.
+        private static func lookupIdentifier(identifier: String) -> KindIdentifier? {
+            switch identifier {
+            case "associatedtype" : return .associatedtype
+            case "class"          : return .class
+            case "deinit"         : return .deinit
+            case "enum"           : return .enum
+            case "enum.case"      : return .case
+            case "func"           : return .func
+            case "func.op"        : return .operator
+            case "init"           : return .`init`
+            case "method"         : return .method
+            case "property"       : return .property
+            case "protocol"       : return .protocol
+            case "struct"         : return .struct
+            case "subscript"      : return .subscript
+            case "type.method"    : return .typeMethod
+            case "type.property"  : return .typeProperty
+            case "type.subscript" : return .typeSubscript
+            case "typealias"      : return .typealias
+            case "var"            : return .var
+            case "module"         : return .module
+            default               : return nil
+            }
+        }
+
+        /// Compares the given identifier against the known default symbol kinds, and returns whether it matches one.
+        ///
+        /// The identifier will also be checked without its first component, so that (for example) `"swift.func"`
+        /// will be treated the same as just `"func"`, and match `.func`.
+        ///
+        /// - Parameter identifier: The identifier string to compare.
+        /// - Returns: `true` if the given identifier matches a known symbol kind; otherwise `false`.
+        public static func isKnownIdentifier(_ identifier: String) -> Bool {
+            var kind: KindIdentifier? = nil
+
+            if let cachedDetail = Self.lookupIdentifier(identifier: identifier) {
+                kind = cachedDetail
+            } else {
+                let cleanIdentifier = KindIdentifier.cleanIdentifier(identifier)
+                kind = Self.lookupIdentifier(identifier: cleanIdentifier)
+            }
+
+            return kind != nil
+        }
+
+        /// Parses the given identifier to return a matching symbol kind.
+        ///
+        /// The identifier will also be checked without its first component, so that (for example) `"swift.func"`
+        /// will be treated the same as just `"func"`, and match `.func`.
+        ///
+        /// - Parameter identifier: The identifier string to parse.
+        public init(identifier: String) {
+            // Check if the identifier matches a symbol kind directly.
+            if let firstParse = Self.lookupIdentifier(identifier: identifier) {
+                self = firstParse
+            } else {
+                // For symbol graphs which include a language identifier with their symbol kinds
+                // (e.g. "swift.func" instead of just "func"), strip off the language prefix and
+                // try again.
+                let cleanIdentifier = KindIdentifier.cleanIdentifier(identifier)
+                self = Self.lookupIdentifier(identifier: cleanIdentifier) ?? .unknown
+            }
+        }
+
+        public init(from decoder: Decoder) throws {
+            let identifier = try decoder.singleValueContainer().decode(String.self)
+            self = KindIdentifier(identifier: identifier)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(identifier)
+        }
+
+        /// Strips the first component of the given identifier string, so that (for example) `"swift.func"` will return `"func"`.
+        ///
+        /// Symbol graphs may store symbol kinds as either bare identifiers (e.g. `"class"`, `"enum"`, etc), or as identifiers
+        /// prefixed with the language identifier (e.g. `"swift.func"`, `"objc.method"`, etc). This method allows us to
+        /// treat the language-prefixed symbol kinds as equivalent to the "bare" symbol kinds.
+        ///
+        /// - Parameter identifier: An identifier string to clean.
+        /// - Returns: A new identifier string without its first component, or the original identifier if there was only one component.
+        private static func cleanIdentifier(_ identifier: String) -> String {
+            // FIXME: Take an "expected" language identifier instead of universally dropping the first component? (rdar://84276085)
+            if let periodIndex = identifier.firstIndex(of: ".") {
+                return String(identifier[identifier.index(after: periodIndex)...])
+            }
+            return identifier
         }
     }
 }

--- a/Sources/SymbolKit/SymbolGraph/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/SymbolGraph/UnifiedSymbolGraph/GraphCollector.swift
@@ -1,0 +1,120 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// An accumulator for incrementally merging ``SymbolGraph``s into ``UnifiedSymbolGraph``s.
+public class GraphCollector {
+    /// An indicator of whether a loaded symbol graph was a "primary" symbol graph or one that contained
+    /// extensions from a different module.
+    public enum GraphKind {
+        case primary(URL)
+        case `extension`(URL)
+    }
+
+    /// The list of merged symbol graphs, indexed by module name.
+    var unifiedGraphs: [String: UnifiedSymbolGraph] = [:]
+
+    /// The list of files that contributed to each merged symbol graph, indexed by module name.
+    var graphSources: [String: [GraphKind]] = [:]
+
+    var extensionGraphs: [URL: SymbolGraph] = [:]
+
+    public init() {
+        self.unifiedGraphs = [:]
+        self.graphSources = [:]
+        self.extensionGraphs = [:]
+    }
+}
+
+extension GraphCollector {
+    /// Merges the given ``SymbolGraph`` into the set of unified symbol graphs.
+    ///
+    /// - Parameters:
+    ///   - inputGraph: The symbol graph to merge in.
+    ///   - url: The file name where the given symbol graph is located. Used to determine whether a symbol graph
+    ///     contains primary symbols or extensions.
+    public func mergeSymbolGraph(_ inputGraph: SymbolGraph, at url: URL, forceLoading: Bool = false) {
+        var graph = inputGraph
+        let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(graph, at: url)
+
+        if !isMainSymbolGraph && !forceLoading {
+            graph.module.name = moduleName
+            self.extensionGraphs[url] = graph
+            return
+        }
+
+        if let existingGraph = self.unifiedGraphs[moduleName] {
+            existingGraph.mergeGraph(graph: graph, at: url)
+        } else {
+            self.unifiedGraphs[moduleName] = UnifiedSymbolGraph(fromSingleGraph: graph, at: url)
+        }
+
+        let graphURL: GraphKind
+        if isMainSymbolGraph {
+            graphURL = .primary(url)
+        } else {
+            graphURL = .`extension`(url)
+        }
+
+        if var existingSources = self.graphSources[moduleName] {
+            existingSources.append(graphURL)
+        } else {
+            self.graphSources[moduleName] = [graphURL]
+        }
+    }
+
+    public func finishLoading() -> (unifiedGraphs: [String: UnifiedSymbolGraph], graphSources: [String: [GraphKind]]) {
+        for (url, graph) in self.extensionGraphs {
+            self.mergeSymbolGraph(graph, at: url, forceLoading: true)
+        }
+
+        return (self.unifiedGraphs, self.graphSources)
+    }
+
+    /// Determines the module name for the given symbol graph.
+    ///
+    /// For Swift, symbol graphs are separated based on whether symbols are extending other symbols in other modules.
+    /// Symbols declared in the module itself are saved in a symbol graph file named `ModuleName.symbols.json`,
+    /// whereas symbols that extend a different module are saved in a separate file named
+    /// `ModuleName@OtherModule.symbols.json`. The latter symbol graph file still declares its module
+    /// as `ModuleName`, so this function allows consumers of symbol graphs to determine which module to load
+    /// symbols under.
+    ///
+    /// - Parameters:
+    ///   - graph: The symbol graph being checked.
+    ///   - url: The file name where the symbol graph is located.
+    /// - Returns: The name of the module described by `graph`, and whether the symbol graph is a "primary" symbol graph.
+    public static func moduleNameFor(_ graph: SymbolGraph, at url: URL) -> (String, Bool) {
+        let isMainSymbolGraph = !url.lastPathComponent.contains("@")
+
+        let moduleName: String
+        if isMainSymbolGraph {
+            // For main symbol graphs, get the module name from the symbol graph's data
+            moduleName = graph.module.name
+        } else {
+            // For extension symbol graphs, derive the extended module's name from the file name.
+            //
+            // The per-symbol `extendedModule` value is the same as the main module for most symbols, so it's not a good way to find the name
+            // of the module that was extended (rdar://63200368).
+            let fileName = url.lastPathComponent.components(separatedBy: ".symbols.json")[0]
+
+            let fileNameComponents = fileName.components(separatedBy: "@")
+            if fileNameComponents.count > 2 {
+                // For a while, cross-import overlay symbol graphs had more than two components:
+                // "Framework1@Framework2@_Framework1_Framework2.symbols.json"
+                moduleName = fileNameComponents[0]
+            } else {
+                moduleName = fileName.split(separator: "@", maxSplits: 1).last.map({ String($0) })!
+            }
+        }
+        return (moduleName, isMainSymbolGraph)
+    }
+}

--- a/Sources/SymbolKit/SymbolGraph/UnifiedSymbolGraph/UnifiedSymbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/UnifiedSymbolGraph/UnifiedSymbol.swift
@@ -1,0 +1,100 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension UnifiedSymbolGraph {
+    /// A combined symbol from multiple languages' views of the same symbol.
+    public class Symbol {
+        /// The unique identifier for the symbol.
+        ///
+        /// This is intended to be unique across languages, and is used to select symbol information to combine.
+        public var uniqueIdentifier: String
+
+        /// The selector that originated from the "main module" symbol graph, as opposed to an extension.
+        public var mainGraphSelectors: [Selector]
+
+        public var modules: [Selector: SymbolGraph.Module]
+
+        /// The kind of symbol.
+        public var kind: [Selector: SymbolGraph.Symbol.Kind]
+
+        /// A short convenience path that uniquely identifies a symbol when there are no ambiguities using only URL-compatible characters.
+        ///
+        /// See ``SymbolGraph/Symbol/pathComponents`` for more information. This is separated per-language to allow for language-specific symbol/module/namespace names to reference the symbol.
+        public var pathComponents: [Selector: [String]]
+
+        /// If the static type of a symbol is known, the precise identifier of
+        /// the symbol that declares the type.
+        public var type: String?
+
+        /// The context-specific names of a symbol.
+        public var names: [Selector: SymbolGraph.Symbol.Names]
+
+        /// The in-source documentation comment attached to a symbol.
+        public var docComment: [Selector: SymbolGraph.LineList]
+
+        /// The access level of the symbol.
+        public var accessLevel: [Selector: SymbolGraph.Symbol.AccessControl]
+
+        /// Information about a symbol that is not necessarily common to all symbols.
+        public var mixins: [Selector: [String: Mixin]]
+
+        /// Initialize a combined symbol view from a single symbol.
+        public init(fromSingleSymbol sym: SymbolGraph.Symbol, module: SymbolGraph.Module, isMainGraph: Bool) {
+            let lang = sym.identifier.interfaceLanguage
+            let selector = Selector(interfaceLanguage: lang, platform: module.platform.name)
+
+            self.uniqueIdentifier = sym.identifier.precise
+            self.mainGraphSelectors = []
+            if isMainGraph {
+                self.mainGraphSelectors.append(selector)
+            }
+            self.modules = [selector: module]
+            self.kind = [selector: sym.kind]
+            self.pathComponents = [selector: sym.pathComponents]
+            self.type = sym.type
+            self.names = [selector: sym.names]
+            self.docComment = [:]
+            if let docComment = sym.docComment {
+                self.docComment[selector] = docComment
+            }
+            self.accessLevel = [selector: sym.accessLevel]
+            self.mixins = [selector: sym.mixins]
+        }
+
+        /// Add the given symbol to this unified view.
+        ///
+        /// - Warning: `symbol` must refer to the same symbol as this view (i.e. their precise identifiers must be the same).
+        ///
+        /// - Parameters:
+        ///   - symbol: The symbol to add to this view.
+        public func mergeSymbol(symbol: SymbolGraph.Symbol, module: SymbolGraph.Module, isMainGraph: Bool) {
+            precondition(self.uniqueIdentifier == symbol.identifier.precise)
+
+            let selector = Selector(
+                interfaceLanguage: symbol.identifier.interfaceLanguage,
+                platform: module.platform.name)
+
+            if isMainGraph && !self.mainGraphSelectors.contains(selector) {
+                self.mainGraphSelectors.append(selector)
+            }
+
+            // Add a new variant to the fields that track it
+            self.modules[selector] = module
+            self.kind[selector] = symbol.kind
+            self.pathComponents[selector] = symbol.pathComponents
+            self.names[selector] = symbol.names
+            self.docComment[selector] = symbol.docComment
+            self.accessLevel[selector] = symbol.accessLevel
+            self.mixins[selector] = symbol.mixins
+        }
+    }
+}

--- a/Sources/SymbolKit/SymbolGraph/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
+++ b/Sources/SymbolKit/SymbolGraph/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
@@ -1,0 +1,120 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+/// A combined ``SymbolGraph`` from multiple languages' views of the same module.
+public class UnifiedSymbolGraph {
+
+    /// The module that these combined symbol graphs represent.
+    public var moduleName: String
+
+    /// The decoded metadata about the module being represented, indexed by the file path of the symbol graph it was decoded from.
+    ///
+    /// Some module symbol graphs contain different metadata (e.g. platform it was rendered for, "bystander" modules, etc), and this allows users of unified graph data to load individual graphs' module data.
+    public var moduleData: [URL: SymbolGraph.Module]
+
+    /// Metadata about the individual symbol graphs that were combined together, indexed by the file path of each input symbol graph.
+    public var metadata: [URL: SymbolGraph.Metadata]
+
+    /// The symbols in the module, indexed by precise identifier.
+    public var symbols: [String: UnifiedSymbolGraph.Symbol]
+
+    /// The relationships between symbols.
+    public var relationships: [SymbolGraph.Relationship]
+
+    public init?(fromSingleGraph graph: SymbolGraph, at url: URL) {
+        let (_, isMainGraph) = GraphCollector.moduleNameFor(graph, at: url)
+
+        self.moduleName = graph.module.name
+        self.moduleData = [url: graph.module]
+        self.metadata = [url: graph.metadata]
+        self.symbols = graph.symbols.mapValues { UnifiedSymbolGraph.Symbol(fromSingleSymbol: $0, module: graph.module, isMainGraph: isMainGraph) }
+        self.relationships = graph.relationships
+    }
+}
+
+extension UnifiedSymbolGraph {
+    /// Merge the given list of ``SymbolGraph/Relationship``s with the list in this graph.
+    ///
+    /// This function will deduplicate relationships based on their source, target, and kind. If it sees a duplicate, it will keep the first one it sees.
+    func mergeRelationships(with otherRelations: [SymbolGraph.Relationship]) {
+        struct RelationKey: Hashable {
+            let source: String
+            let target: String
+            let kind: SymbolGraph.Relationship.Kind
+
+            init(fromRelation relationship: SymbolGraph.Relationship) {
+                self.source = relationship.source
+                self.target = relationship.target
+                self.kind = relationship.kind
+            }
+
+            static func makePair(fromRelation relationship: SymbolGraph.Relationship) -> (RelationKey, SymbolGraph.Relationship) {
+                return (RelationKey(fromRelation: relationship), relationship)
+            }
+        }
+
+        // first add the new relations to this one
+        self.relationships.append(contentsOf: otherRelations)
+
+        // deduplicate the combined relationships array by source/target/kind
+        // FIXME: Actually merge relationships if they have different mixins (rdar://84267943)
+        let map = [:].merging(self.relationships.map({ RelationKey.makePair(fromRelation: $0) }), uniquingKeysWith: { r1, r2 in r1 })
+
+        self.relationships = Array(map.values)
+    }
+
+    /// Merge the given symbol graph with this one.
+    public func mergeGraph(graph: SymbolGraph, at url: URL) {
+        let (_, isMainGraph) = GraphCollector.moduleNameFor(graph, at: url)
+
+        self.metadata[url] = graph.metadata
+        self.moduleData[url] = graph.module
+
+        self.mergeRelationships(with: graph.relationships)
+
+        for (key: precise, value: sym) in graph.symbols {
+            if let existingSymbol = self.symbols[precise] {
+                existingSymbol.mergeSymbol(symbol: sym, module: graph.module, isMainGraph: isMainGraph)
+            } else {
+                self.symbols[precise] = Symbol(fromSingleSymbol: sym, module: graph.module, isMainGraph: isMainGraph)
+            }
+        }
+    }
+}
+
+extension UnifiedSymbolGraph {
+    /// A combination of interface language and list of platforms that allows a symbol to be distinguished from another when unifying symbol graphs.
+    public struct Selector: Equatable, Hashable {
+        /// The interface language used for the symbol.
+        public let interfaceLanguage: String
+
+        /// The platform that the symbol was built for.
+        ///
+        /// If the symbol graph that the symbol was sourced from does not contain a `module.platform.operatingSystem`, this will be `nil`.
+        public let platform: String?
+
+        public init(interfaceLanguage: String, platform: String?) {
+            self.interfaceLanguage = interfaceLanguage
+            self.platform = platform
+        }
+
+        /// Creates a ``UnifiedSymbolGraph/Selector`` for the given symbol graph's language and platform.
+        ///
+        /// If `graph` has no symbols, this will return `nil`.
+        public init?(forSymbolGraph graph: SymbolGraph) {
+            guard let lang = graph.symbols.first?.value.identifier.interfaceLanguage else { return nil }
+
+            self.interfaceLanguage = lang
+            self.platform = graph.module.platform.name
+        }
+    }
+}

--- a/Tests/SymbolKitTests/Symbol/SymbolKindTests.swift
+++ b/Tests/SymbolKitTests/Symbol/SymbolKindTests.swift
@@ -1,0 +1,94 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Foundation
+@testable import SymbolKit
+
+class SymbolKindTests: XCTestCase {
+    
+    func testKindParsing() throws {
+        var kind: SymbolGraph.Symbol.KindIdentifier
+
+        // Verify basic parsing of old style identifier is working.
+        XCTAssert(SymbolGraph.Symbol.KindIdentifier.isKnownIdentifier("swift.func"))
+        kind = SymbolGraph.Symbol.KindIdentifier(identifier: "swift.func")
+        XCTAssertEqual(kind, .func)
+        XCTAssertEqual(kind.identifier, "func")
+
+        // Verify new language-agnostic type is recognized.
+        XCTAssert(SymbolGraph.Symbol.KindIdentifier.isKnownIdentifier("func"))
+        kind = SymbolGraph.Symbol.KindIdentifier(identifier: "func")
+        XCTAssertEqual(kind, .func)
+        XCTAssertEqual(kind.identifier, "func")
+
+        // Verify a bare language is not recognized.
+        XCTAssertFalse(SymbolGraph.Symbol.KindIdentifier.isKnownIdentifier("swift"))
+        kind = SymbolGraph.Symbol.KindIdentifier(identifier: "swift")
+        XCTAssertEqual(kind, .unknown)
+
+        // Verify if nothing is recognized, identifier and name is still there.
+        XCTAssertFalse(SymbolGraph.Symbol.KindIdentifier.isKnownIdentifier("swift.madeupapi"))
+        kind = SymbolGraph.Symbol.KindIdentifier(identifier: "swift.madeupapi")
+        XCTAssertEqual(kind, .unknown)
+    }
+
+    func testKindDecoding() throws {
+        var schemaData: Data
+        var kindJson: String
+        
+        let jsonDecoder = JSONDecoder()
+
+        kindJson = """
+            {"identifier": "swift.func", "displayName": "Function"}
+        """
+        schemaData = kindJson.data(using: .utf8)!
+        let kind = try jsonDecoder.decode(SymbolGraph.Symbol.Kind.self, from: schemaData)
+        XCTAssertNotNil(kind)
+        XCTAssertEqual(kind.identifier, .func)
+        XCTAssertEqual(kind.displayName, "Function")
+        
+        // Verify that the identifier can parse without the "swift." prefix
+        kindJson = """
+            "func"
+        """
+        schemaData = kindJson.data(using: .utf8)!
+        let identifier = try jsonDecoder.decode(SymbolGraph.Symbol.KindIdentifier.self, from: schemaData)
+        XCTAssertNotNil(identifier)
+        XCTAssertEqual(identifier, .func)
+    }
+    
+    func testIdentifierRetrieval() throws {
+        var theCase: SymbolGraph.Symbol.KindIdentifier
+        
+        theCase = .class
+        XCTAssertEqual(theCase.identifier, "class")
+    }
+
+    func testVariousLanguagePrefixes() throws {
+        let identifiers = ["func", "swift.func", "objc.func"]
+        let jsonDecoder = JSONDecoder()
+
+        for identifier in identifiers {
+            let parsed = SymbolGraph.Symbol.KindIdentifier(identifier: identifier)
+
+            XCTAssertEqual(parsed, .func)
+
+            let kindJson = """
+                {"identifier": "\(identifier)", "displayName": "Function"}
+            """
+            let schemaData = kindJson.data(using: .utf8)!
+            let kind = try jsonDecoder.decode(SymbolGraph.Symbol.Kind.self, from: schemaData)
+            XCTAssertNotNil(kind)
+            XCTAssertEqual(kind.identifier, .func)
+            XCTAssertEqual(kind.displayName, "Function")
+        }
+    }
+}

--- a/Tests/SymbolKitTests/UnifiedGraph/UnifiedSymbolTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/UnifiedSymbolTests.swift
@@ -1,0 +1,531 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Foundation
+@testable import SymbolKit
+
+class UnifiedSymbolTests: XCTestCase {
+
+    let swiftSelector = UnifiedSymbolGraph.Selector(interfaceLanguage: "swift", platform: nil)
+    let objcSelector = UnifiedSymbolGraph.Selector(interfaceLanguage: "objc", platform: nil)
+
+    func testCombineSymbols() throws {
+        let demoSwiftSymbol = """
+        {
+            "kind": {
+                "identifier": "swift.class",
+                "displayName": "Class"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)PlayingCard",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "PlayingCard"
+            ],
+            "names": {
+                "title": "PlayingCard",
+                "navigator": [
+                    {
+                        "kind": "identifier",
+                        "spelling": "PlayingCard"
+                    }
+                ],
+                "subHeading": [
+                    {
+                        "kind": "keyword",
+                        "spelling": "class"
+                    },
+                    {
+                        "kind": "text",
+                        "spelling": " "
+                    },
+                    {
+                        "kind": "identifier",
+                        "spelling": "PlayingCard"
+                    }
+                ]
+            },
+            "declarationFragments": [
+                {
+                    "kind": "keyword",
+                    "spelling": "class"
+                },
+                {
+                    "kind": "text",
+                    "spelling": " "
+                },
+                {
+                    "kind": "identifier",
+                    "spelling": "PlayingCard"
+                }
+            ],
+            "accessLevel": "open"
+        }
+        """
+
+        let demoObjcSymbol = """
+        {
+            "accessLevel": "public",
+            "identifier": {
+                "interfaceLanguage": "objc",
+                "precise": "c:objc(cs)PlayingCard"
+            },
+            "kind": {
+                "displayName": "Class",
+                "identifier": "swift.class"
+            },
+            "location": {
+                "position": {
+                    "character": 11,
+                    "line": 36
+                },
+                "uri": "PlayingCard.h"
+            },
+            "names": {
+                "title": "PlayingCard"
+            },
+            "pathComponents": [
+                "PlayingCard"
+            ]
+        }
+        """
+
+        let comboSymbol = try mergeTwoSymbols(demoObjcSymbol, demoSwiftSymbol)
+
+        XCTAssertEqual(comboSymbol.uniqueIdentifier, "c:objc(cs)PlayingCard")
+
+        XCTAssertEqual(comboSymbol.kind[swiftSelector]?.identifier, .class)
+        XCTAssertEqual(comboSymbol.kind[objcSelector]?.identifier, .class)
+
+        XCTAssertEqual(comboSymbol.pathComponents[swiftSelector], ["PlayingCard"])
+        XCTAssertEqual(comboSymbol.pathComponents[objcSelector], ["PlayingCard"])
+
+        XCTAssertNil(comboSymbol.type)
+
+        XCTAssertEqual(comboSymbol.names[swiftSelector],
+            SymbolGraph.Symbol.Names(
+                title: "PlayingCard",
+                navigator: [
+                    SymbolGraph.Symbol.DeclarationFragments.Fragment(
+                        kind: .identifier,
+                        spelling: "PlayingCard",
+                        preciseIdentifier: nil)
+                ],
+                subHeading: [
+                    SymbolGraph.Symbol.DeclarationFragments.Fragment(
+                        kind: .keyword,
+                        spelling: "class",
+                        preciseIdentifier: nil),
+                    SymbolGraph.Symbol.DeclarationFragments.Fragment(
+                        kind: .text,
+                        spelling: " ",
+                        preciseIdentifier: nil),
+                    SymbolGraph.Symbol.DeclarationFragments.Fragment(
+                        kind: .identifier,
+                        spelling: "PlayingCard",
+                        preciseIdentifier: nil)
+                ],
+                prose: nil))
+        XCTAssertEqual(comboSymbol.names[objcSelector],
+            SymbolGraph.Symbol.Names(
+                title: "PlayingCard",
+                navigator: nil,
+                subHeading: nil,
+                prose: nil))
+
+        XCTAssert(comboSymbol.docComment.isEmpty)
+
+        XCTAssertEqual(comboSymbol.accessLevel[swiftSelector],
+                       SymbolGraph.Symbol.AccessControl(rawValue: "open"))
+        XCTAssertEqual(comboSymbol.accessLevel[objcSelector],
+                       SymbolGraph.Symbol.AccessControl(rawValue: "public"))
+
+        do {
+            XCTAssertEqual(comboSymbol.mixins[swiftSelector]?.count, 1)
+
+            let declarationFragments = try XCTUnwrap(comboSymbol.mixins[swiftSelector]?["declarationFragments"] as? SymbolGraph.Symbol.DeclarationFragments)
+
+            XCTAssertEqual(declarationFragments.declarationFragments,
+                [
+                    SymbolGraph.Symbol.DeclarationFragments.Fragment(
+                        kind: .keyword,
+                        spelling: "class",
+                        preciseIdentifier: nil),
+                    SymbolGraph.Symbol.DeclarationFragments.Fragment(
+                        kind: .text,
+                        spelling: " ",
+                        preciseIdentifier: nil),
+                    SymbolGraph.Symbol.DeclarationFragments.Fragment(
+                        kind: .identifier,
+                        spelling: "PlayingCard",
+                        preciseIdentifier: nil)
+                ]
+            )
+        }
+
+        do {
+            XCTAssertEqual(comboSymbol.mixins[objcSelector]?.count, 1)
+
+            let location = try XCTUnwrap(comboSymbol.mixins[objcSelector]?["location"] as? SymbolGraph.Symbol.Location)
+
+            XCTAssertEqual(location.uri, "PlayingCard.h")
+            XCTAssertEqual(location.position,
+                SymbolGraph.LineList.SourceRange.Position(
+                    line: 36,
+                    character: 11))
+        }
+    }
+
+    func testDocCommentMerging() throws {
+        let demoSwiftSymbol = """
+        {
+            "kind": {
+                "identifier": "swift.init",
+                "displayName": "Initializer"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "PlayingCard",
+                "init(rank:of:)"
+            ],
+            "names": {
+                "title": "init(rank:of:)",
+            },
+            "accessLevel": "public"
+        }
+        """
+
+        let demoObjcSymbol = """
+        {
+            "accessLevel": "public",
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "end": {
+                                "character": 51,
+                                "line": 41
+                            },
+                            "start": {
+                                "character": 4,
+                                "line": 41
+                            }
+                        },
+                        "text": "Initialize a card with the given rank and suit."
+                    }
+                ]
+            },
+            "identifier": {
+                "interfaceLanguage": "objc",
+                "precise": "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:"
+            },
+            "kind": {
+                "displayName": "Instance Method",
+                "identifier": "swift.method"
+            },
+            "location": {
+                "position": {
+                    "character": 0,
+                    "line": 42
+                },
+                "uri": "PlayingCard.h"
+            },
+            "names": {
+                "title": "initWithRank:ofSuit:"
+            },
+            "pathComponents": [
+                "PlayingCard",
+                "initWithRank:ofSuit:"
+            ]
+        }
+        """
+
+        func verifySymbol(comboSymbol: UnifiedSymbolGraph.Symbol) {
+            XCTAssertNil(comboSymbol.docComment[swiftSelector])
+
+            guard let docs = comboSymbol.docComment[objcSelector] else {
+                XCTFail("Expected single doc comment from test, got something else")
+                return
+            }
+
+            XCTAssertEqual(docs.lines, [
+                SymbolGraph.LineList.Line(
+                    text: "Initialize a card with the given rank and suit.",
+                    range: SymbolGraph.LineList.SourceRange(
+                        start: SymbolGraph.LineList.SourceRange.Position(
+                            line: 41,
+                            character: 4),
+                        end: SymbolGraph.LineList.SourceRange.Position(
+                            line: 41,
+                            character: 51)))
+            ])
+        }
+
+        // Test loading the symbols in either order, so that we can load the comment in either case
+        let combo1 = try mergeTwoSymbols(demoObjcSymbol, demoSwiftSymbol)
+        verifySymbol(comboSymbol: combo1)
+
+        let combo2 = try mergeTwoSymbols(demoSwiftSymbol, demoObjcSymbol)
+        verifySymbol(comboSymbol: combo2)
+    }
+
+    func testDocCommentMergeIdentical() throws {
+        let demoSwiftSymbol = """
+        {
+            "kind": {
+                "identifier": "swift.init",
+                "displayName": "Initializer"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "PlayingCard",
+                "init(rank:of:)"
+            ],
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "end": {
+                                "character": 51,
+                                "line": 41
+                            },
+                            "start": {
+                                "character": 4,
+                                "line": 41
+                            }
+                        },
+                        "text": "Initialize a card with the given rank and suit."
+                    }
+                ]
+            },
+            "names": {
+                "title": "init(rank:of:)",
+            },
+            "accessLevel": "public"
+        }
+        """
+
+        let demoObjcSymbol = """
+        {
+            "accessLevel": "public",
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "end": {
+                                "character": 51,
+                                "line": 41
+                            },
+                            "start": {
+                                "character": 4,
+                                "line": 41
+                            }
+                        },
+                        "text": "Initialize a card with the given rank and suit."
+                    }
+                ]
+            },
+            "identifier": {
+                "interfaceLanguage": "objc",
+                "precise": "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:"
+            },
+            "kind": {
+                "displayName": "Instance Method",
+                "identifier": "swift.method"
+            },
+            "location": {
+                "position": {
+                    "character": 0,
+                    "line": 42
+                },
+                "uri": "PlayingCard.h"
+            },
+            "names": {
+                "title": "initWithRank:ofSuit:"
+            },
+            "pathComponents": [
+                "PlayingCard",
+                "initWithRank:ofSuit:"
+            ]
+        }
+        """
+
+        func verifySymbol(comboSymbol: UnifiedSymbolGraph.Symbol) {
+            XCTAssertEqual(comboSymbol.docComment.count, 2)
+
+            for docs in comboSymbol.docComment.values {
+                XCTAssertEqual(docs.lines, [
+                    SymbolGraph.LineList.Line(
+                        text: "Initialize a card with the given rank and suit.",
+                        range: SymbolGraph.LineList.SourceRange(
+                            start: SymbolGraph.LineList.SourceRange.Position(
+                                line: 41,
+                                character: 4),
+                            end: SymbolGraph.LineList.SourceRange.Position(
+                                line: 41,
+                                character: 51)))
+                ])
+            }
+        }
+
+        // Test loading the symbols in either order, so that we can load the comment in either case
+        let combo1 = try mergeTwoSymbols(demoObjcSymbol, demoSwiftSymbol)
+        verifySymbol(comboSymbol: combo1)
+
+        let combo2 = try mergeTwoSymbols(demoSwiftSymbol, demoObjcSymbol)
+        verifySymbol(comboSymbol: combo2)
+    }
+
+    func testDocCommentMergeDifferent() throws {
+        let demoSwiftSymbol = """
+        {
+            "kind": {
+                "identifier": "swift.init",
+                "displayName": "Initializer"
+            },
+            "identifier": {
+                "precise": "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:",
+                "interfaceLanguage": "swift"
+            },
+            "pathComponents": [
+                "PlayingCard",
+                "init(rank:of:)"
+            ],
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "end": {
+                                "character": 51,
+                                "line": 41
+                            },
+                            "start": {
+                                "character": 4,
+                                "line": 41
+                            }
+                        },
+                        "text": "Create a new card with the given rank and suit."
+                    }
+                ]
+            },
+            "names": {
+                "title": "init(rank:of:)",
+            },
+            "accessLevel": "public"
+        }
+        """
+
+        let demoObjcSymbol = """
+        {
+            "accessLevel": "public",
+            "docComment": {
+                "lines": [
+                    {
+                        "range": {
+                            "end": {
+                                "character": 51,
+                                "line": 41
+                            },
+                            "start": {
+                                "character": 4,
+                                "line": 41
+                            }
+                        },
+                        "text": "Initialize a card with the given rank and suit."
+                    }
+                ]
+            },
+            "identifier": {
+                "interfaceLanguage": "objc",
+                "precise": "c:objc(cs)PlayingCard(im)initWithRank:ofSuit:"
+            },
+            "kind": {
+                "displayName": "Instance Method",
+                "identifier": "swift.method"
+            },
+            "location": {
+                "position": {
+                    "character": 0,
+                    "line": 42
+                },
+                "uri": "PlayingCard.h"
+            },
+            "names": {
+                "title": "initWithRank:ofSuit:"
+            },
+            "pathComponents": [
+                "PlayingCard",
+                "initWithRank:ofSuit:"
+            ]
+        }
+        """
+
+        func verifySymbol(comboSymbol: UnifiedSymbolGraph.Symbol) {
+            XCTAssertEqual(comboSymbol.docComment.count, 2)
+
+            XCTAssertEqual(comboSymbol.docComment[objcSelector]?.lines, [
+                SymbolGraph.LineList.Line(
+                    text: "Initialize a card with the given rank and suit.",
+                    range: SymbolGraph.LineList.SourceRange(
+                        start: SymbolGraph.LineList.SourceRange.Position(
+                            line: 41,
+                            character: 4),
+                        end: SymbolGraph.LineList.SourceRange.Position(
+                            line: 41,
+                            character: 51)))
+            ])
+
+            XCTAssertEqual(comboSymbol.docComment[swiftSelector]?.lines, [
+                SymbolGraph.LineList.Line(
+                    text: "Create a new card with the given rank and suit.",
+                    range: SymbolGraph.LineList.SourceRange(
+                        start: SymbolGraph.LineList.SourceRange.Position(
+                            line: 41,
+                            character: 4),
+                        end: SymbolGraph.LineList.SourceRange.Position(
+                            line: 41,
+                            character: 51)))
+            ])
+        }
+
+        // Test loading the symbols in either order, so that we can load the comment in either case
+        let combo1 = try mergeTwoSymbols(demoObjcSymbol, demoSwiftSymbol)
+        verifySymbol(comboSymbol: combo1)
+
+        let combo2 = try mergeTwoSymbols(demoSwiftSymbol, demoObjcSymbol)
+        verifySymbol(comboSymbol: combo2)
+    }
+
+    func mergeTwoSymbols(_ sym1: String, _ sym2: String) throws -> UnifiedSymbolGraph.Symbol {
+        let decoder = JSONDecoder()
+
+        let data1 = sym1.data(using: .utf8)!
+        let decoded1 = try decoder.decode(SymbolGraph.Symbol.self, from: data1)
+
+        let data2 = sym2.data(using: .utf8)!
+        let decoded2 = try decoder.decode(SymbolGraph.Symbol.self, from: data2)
+
+        let module = SymbolGraph.Module(name: "TestModule", platform: SymbolGraph.Platform(architecture: nil, vendor: nil, operatingSystem: nil, environment: nil), version: nil, bystanders: nil)
+
+        let comboSymbol = UnifiedSymbolGraph.Symbol(fromSingleSymbol: decoded1, module: module, isMainGraph: true)
+        comboSymbol.mergeSymbol(symbol: decoded2, module: module, isMainGraph: false)
+
+        return comboSymbol
+    }
+
+}


### PR DESCRIPTION
This is the SymbolKit implementation of [this recent forums proposal](https://forums.swift.org/t/extending-swift-docc-to-support-objective-c-documentation/53243) to enable Objective-C support in Swift-DocC. This introduces the `UnifiedSymbolGraph`, `UnifiedSymbolGraph.Symbol`, and `GraphCollector` types that can be used to combine symbols and symbol graphs into a "unified" or "composite" symbol graph, that collects symbols together based on describing the same symbol or existing in the same module. These "unified symbol graph" types augment the existing symbol graph types by allowing a way to collect alternate versions of the same API. The existing `SymbolGraph` and `SymbolGraph.Symbol` types remain unchanged, and they can (and should!) still be used to decode symbol graphs from disk.

This PR also includes a refactoring to the Symbol API: An update to the symbol kind that parses them into an enum of known kinds, instead of storing the raw string. This is in service of enabling support in Swift-DocC for documentation of languages other than Swift; at the moment, DocC parses the symbol kinds itself to automatically organize documentation, but assumes symbol kinds that start with `swift`. By parsing them here, DocC can extend its automatic organization to non-Swift documentation by using this new enum instead of parsing the symbol kinds itself.

The `Codable` implementation of the new `KindIdentifier` enum will allow for an arbitrary language prefix on the symbol kind (e.g. `"swift.func"` and `"objc.func"` instead of just `"func"`). This will allow symbol graph representations to include the language identifier in their symbol kinds.