### PR TITLE
Support 'macos' as a valid OS identifier

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Platform.swift
+++ b/Sources/SymbolKit/SymbolGraph/Platform.swift
@@ -48,7 +48,7 @@ extension SymbolGraph {
                 return nil
             }
             switch os {
-            case "macosx":
+            case "macosx", "macos":
                 return SymbolGraph.Symbol.Availability.Domain.macOS
             case "ios":
                 if environment == "macabi" {

--- a/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
@@ -1,0 +1,36 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import SymbolKit
+
+class PlatformTests: XCTestCase {
+    func testMacosIsValidOperatingSystem() {
+        let macosPlatform = SymbolGraph.Platform(
+            architecture: nil,
+            vendor: nil,
+            operatingSystem: SymbolGraph.OperatingSystem(name: "macos"),
+            environment: nil
+        )
+        
+        XCTAssertEqual(macosPlatform.name, "macOS", "'macos' should be a valid OS identifier.")
+    }
+    
+    func testMacosxIsValidOperatingSystem() {
+        let macosxPlatform = SymbolGraph.Platform(
+            architecture: nil,
+            vendor: nil,
+            operatingSystem: SymbolGraph.OperatingSystem(name: "macosx"),
+            environment: nil
+        )
+        
+        XCTAssertEqual(macosPlatform.name, "macOS", "'macosx' should be a valid OS identifier.")
+    }
+}


### PR DESCRIPTION
'macos' is commonly used to identify macOS so we should allow it allongside 'macosx'.

Resolves rdar://85277688