### PR TITLE
fix variable name in PlatformTests

### DIFF
--- a/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/PlatformTests.swift
@@ -31,6 +31,6 @@ class PlatformTests: XCTestCase {
             environment: nil
         )
         
-        XCTAssertEqual(macosPlatform.name, "macOS", "'macosx' should be a valid OS identifier.")
+        XCTAssertEqual(macosxPlatform.name, "macOS", "'macosx' should be a valid OS identifier.")
     }
 }


### PR DESCRIPTION
It looks like #4 included a typo in one of the variable names in the tests. This slipped through when integrating in Swift-DocC, but running the SymbolKit tests locally causes a build failure.