### PR TITLE
Add snippet mixin for symbols

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/LineList/LineList.swift
+++ b/Sources/SymbolKit/SymbolGraph/LineList/LineList.swift
@@ -92,7 +92,7 @@ extension SymbolGraph {
         /// The lines making up this line list.
         public var lines: [Line]
 
-        init(_ lines: [Line]) {
+        public init(_ lines: [Line]) {
             self.lines = lines
         }
 
@@ -196,7 +196,7 @@ extension SymbolGraph.LineList {
         /// The line's range in a document if available.
         public var range: SourceRange?
 
-        init(text: String, range: SourceRange?) {
+        public init(text: String, range: SourceRange?) {
             self.text = text
             self.range = range
         }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol+Snippet.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol+Snippet.swift
@@ -1,0 +1,47 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+extension SymbolGraph.Symbol {
+    public struct Snippet: Mixin, Codable {
+        public struct Chunk: Codable {
+            public var name: String?
+            public var language: String?
+            public var code: String
+            public init(name: String?, language: String?, code: String) {
+                self.name = name
+                self.language = language
+                self.code = code
+            }
+        }
+
+        public static let mixinKey = "snippet"
+
+        public var chunks: [Chunk]
+
+        enum CodingKeys: String, CodingKey {
+            case chunks
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let chunks = try container.decode([Chunk].self, forKey: .chunks)
+            self.init(chunks: chunks)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(chunks, forKey: .chunks)
+        }
+
+        public init(chunks: [Chunk]) {
+            self.chunks = chunks
+        }
+    }
+}

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -105,6 +105,7 @@ extension SymbolGraph {
             case location
             case functionSignature
             case spi
+            case snippet
 
             static var mixinKeys: Set<CodingKeys> {
                 return [
@@ -116,6 +117,7 @@ extension SymbolGraph {
                     .location,
                     .functionSignature,
                     .spi,
+                    .snippet,
                 ]
             }
         }
@@ -170,6 +172,8 @@ extension SymbolGraph {
                     try container.encode(mixin as! FunctionSignature, forKey: key)
                 case .spi:
                     try container.encode(mixin as! SPI, forKey: key)
+                case .snippet:
+                    try container.encode(mixin as! Snippet, forKey: key)
                 default:
                     fatalError("Unknown mixin key \(key.rawValue)!")
                 }
@@ -194,6 +198,8 @@ extension SymbolGraph {
                 return try container.decode(Swift.Generics.self, forKey: key)
             case SPI.mixinKey:
                 return try container.decode(SPI.self, forKey: key)
+            case Snippet.mixinKey:
+                return try container.decode(Snippet.self, forKey: key)
             default:
                 return nil
             }


### PR DESCRIPTION
Snippets need a place to put the chunks of its code listing.

Chunks contain source code, and an optional source language and
name for a subheading at the minimum.