### PR TITLE
Improve public API surface

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/LineList/SourceRange/SourceRange+Position.swift
+++ b/Sources/SymbolKit/SymbolGraph/LineList/SourceRange/SourceRange+Position.swift
@@ -24,5 +24,13 @@ extension SymbolGraph.LineList.SourceRange {
          The zero-based *byte offset* into a line.
          */
         public var character: Int
+        
+        /**
+         Create a new cursor position with the given line number and character offset.
+         */
+        public init(line: Int, character: Int) {
+            self.line = line
+            self.character = character
+        }
     }
 }

--- a/Sources/SymbolKit/SymbolGraph/LineList/SourceRange/SourceRange.swift
+++ b/Sources/SymbolKit/SymbolGraph/LineList/SourceRange/SourceRange.swift
@@ -24,5 +24,13 @@ extension SymbolGraph.LineList {
          The range's end position.
          */
         public var end: Position
+        
+        /**
+         Create a new source range with the given start and end position.
+         */
+        public init(start: Position, end: Position) {
+            self.start = start
+            self.end = end
+        }
     }
 }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol+Location.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol+Location.swift
@@ -12,7 +12,7 @@ import Foundation
 
 extension SymbolGraph.Symbol {
     /**
-     The place where a symbol was originaly declared in a source file.
+     The place where a symbol was originally declared in a source file.
 
      This information may not always be available for many reasons, such
      as compiler infrastructure limitations, or filesystem security concerns.
@@ -30,5 +30,13 @@ extension SymbolGraph.Symbol {
          The range of the declaration in the file, not including its documentation comment.
          */
         public var position: SymbolGraph.LineList.SourceRange.Position
+        
+        /**
+         Create a new symbol location with the given source file URI and position.
+         */
+        public init(uri: String, position: SymbolGraph.LineList.SourceRange.Position) {
+            self.uri = uri
+            self.position = position
+        }
     }
 }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol+Mutability.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol+Mutability.swift
@@ -24,6 +24,11 @@ extension SymbolGraph.Symbol {
          Whether a symbol is *immutable* or "read-only".
          */
         public var isReadOnly: Bool
+        
+        /// Create a mutability mix-in with the given Boolean value.
+        public init(isReadOnly: Bool) {
+            self.isReadOnly = isReadOnly
+        }
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -174,6 +174,8 @@ extension SymbolGraph {
                     try container.encode(mixin as! SPI, forKey: key)
                 case .snippet:
                     try container.encode(mixin as! Snippet, forKey: key)
+                case .location:
+                    try container.encode(mixin as! Location, forKey: key)
                 default:
                     fatalError("Unknown mixin key \(key.rawValue)!")
                 }

--- a/Tests/SymbolKitTests/SymbolGraph/SymbolGraphCreationTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/SymbolGraphCreationTests.swift
@@ -1,0 +1,155 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+import SymbolKit
+import XCTest
+
+/// Tests symbol graph creation as would be done by clients of SymbolKit.
+///
+/// `SymbolKit` is intentionally imported in this file without `@testable` to verify
+/// that the public API is sufficient for clients.
+class SymbolGraphCreationTests: XCTestCase {
+    func testCreateAndEncodeSymbolGraph() throws {
+        let symbolGraph = SymbolGraph(
+            metadata: .init(
+                formatVersion: .init(
+                    major: 0,
+                    minor: 5,
+                    patch: 0
+                ),
+                generator: "org.swift.SymbolKitTests"
+            ),
+            module: .init(
+                name: "Games",
+                platform: .init(
+                    architecture: nil,
+                    vendor: nil,
+                    operatingSystem: .init(
+                        name: "MyOS",
+                        minimumVersion: .init(major: 1, minor: 2, patch: 3)
+                    ),
+                    environment: nil
+                )
+            ),
+            symbols: [
+                SymbolGraph.Symbol(
+                    identifier: .init(
+                        precise: "c:objc(cs)PlayingCard",
+                        interfaceLanguage: "swift"
+                    ),
+                    names: .init(
+                        title: "PlayingCard",
+                        navigator: [
+                            .init(
+                                kind: .identifier,
+                                spelling: "PlayingCard",
+                                preciseIdentifier: nil
+                            ),
+                        ],
+                        subHeading: [
+                            .init(
+                                kind: .keyword,
+                                spelling: "class",
+                                preciseIdentifier: nil
+                            ),
+                            .init(
+                                kind: .text,
+                                spelling: " ",
+                                preciseIdentifier: nil
+                            ),
+                            .init(
+                                kind: .identifier,
+                                spelling: "PlayingCard",
+                                preciseIdentifier: nil
+                            )
+                        ],
+                        prose: "Playing Card"
+                    ),
+                    pathComponents: ["PlayingCard"],
+                    docComment: .init(
+                        [
+                            .init(
+                                text: "test",
+                                range: .init(
+                                    start: .init(
+                                        line: 0,
+                                        character: 0
+                                    ),
+                                    end: .init(
+                                        line: 0,
+                                        character: 5
+                                    )
+                                )
+                            )
+                        ]
+                    ),
+                    accessLevel: .init(rawValue: "open"),
+                    kind: .init(
+                        parsedIdentifier: .class,
+                        displayName: "Class"
+                    ),
+                    mixins: [
+                        SymbolGraph.Symbol.DeclarationFragments.mixinKey : SymbolGraph.Symbol.DeclarationFragments(
+                            declarationFragments: [
+                                .init(
+                                    kind: .keyword,
+                                    spelling: "class",
+                                    preciseIdentifier: nil
+                                ),
+                                .init(
+                                    kind: .text,
+                                    spelling: " ",
+                                    preciseIdentifier: nil
+                                ),
+                                .init(
+                                    kind: .identifier,
+                                    spelling: "PlayingCard",
+                                    preciseIdentifier: nil
+                                )
+                            ]
+                        ),
+                        SymbolGraph.Symbol.Location.mixinKey : SymbolGraph.Symbol.Location(
+                            uri: "/path/to/PlayingCard.swift",
+                            position: .init(line: 0, character: 0)
+                        ),
+                    ]
+                )
+            ],
+            relationships: [
+                .init(
+                    source: "c:objc(cs)PlayingCard",
+                    target: "c:objc(cs)Deck",
+                    kind: .memberOf,
+                    targetFallback: nil
+                )
+            ]
+        )
+        
+        let sortedJSONEncoder = JSONEncoder()
+        sortedJSONEncoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        
+        let encodedSymbolGraph = try sortedJSONEncoder.encode(symbolGraph)
+        let encodedSymbolGraphString = String(data: encodedSymbolGraph, encoding: .utf8)
+        
+        let decodedSymbolGraph = try JSONDecoder().decode(SymbolGraph.self, from: encodedSymbolGraph)
+        
+        // The SymbolGraph model is not `Equatable` so we re-encode to a string to compare the
+        // equality.
+        let reEncodedSymbolGraph = try sortedJSONEncoder.encode(decodedSymbolGraph)
+        let reEncodedSymbolGraphString = String(data: reEncodedSymbolGraph, encoding: .utf8)
+        
+        XCTAssertEqual(
+            encodedSymbolGraphString,
+            reEncodedSymbolGraphString,
+            "Round-trip SymbolGraph encoding failed."
+        )
+    }
+}


### PR DESCRIPTION
Improves the public API surface of SymbolKit to better allow clients
to create SymbolGraphs using SymbolKit directly.

Also fixes a bug where the `Location` symbol mixin was not encoded as part
of Symbol.

Resolves rdar://88504344.