### PR TITLE
Add the `navigator` property of `Symbol.Names` to the spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -250,6 +250,12 @@ components:
             title:
               description: The name of a symbol when shown as a page title or first-level heading.
               type: string
+            navigator:
+              description: The name of a symbol when displaying in navigators, where there may be limited horizontal space.
+              type: array
+              nullable: true
+              items:
+                $ref: "#/components/schemas/DeclarationFragment"
             subHeading:
               description: The name of a symbol when shown as a subheading, such as a page index or list.
               type: array


### PR DESCRIPTION
Updates the OpenAPI spec that defines Symbol Graphs to include the `navigator` property that can optionally be included as part of `Symbol.Names`.

https://github.com/apple/swift-docc-symbolkit/blob/main/Sources/SymbolKit/SymbolGraph/Symbol/Symbol%2BNames.swift#L26