### PR TITLE
Publish Swift SymbolKit's documentation to GitHub pages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+Bug/issue #, if applicable: 
+
+## Summary
+
+_Provide a description of what your PR addresses, explaining the expected user experience. 
+Also, provide an overview of your implementation._
+
+## Dependencies
+
+_Describe any dependencies this PR might have, such as an associated branch in another repository._
+
+## Testing
+
+_Describe how a reviewer can test the functionality of your PR. Provide test content to test with if
+applicable._
+
+Steps:
+1. _Provide setup instructions._
+2. _Explain in detail how the functionality can be tested._
+
+## Checklist
+
+Make sure you check off the following items. If they cannot be completed, provide a reason.
+
+- [ ] Added tests
+- [ ] Ran the `./bin/test` script and it succeeded
+- [ ] Updated documentation if necessary

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 xcuserdata/
 SymbolGraph.symbols.json
 .swiftpm
+Package.resolved
+.vscode

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -16,18 +16,11 @@ import PackageDescription
 let package = Package(
     name: "SymbolKit",
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "SymbolKit",
             targets: ["SymbolKit"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SymbolKit",
             dependencies: []),

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -27,10 +27,3 @@ let package = Package(
             dependencies: ["SymbolKit"]),
     ]
 )
-
-// SwiftPM command plugins are only supported by Swift version 5.6 and later.
-#if swift(>=5.6)
-package.dependencies += [
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-]
-#endif

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -2,7 +2,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,18 +14,11 @@ import PackageDescription
 let package = Package(
     name: "SymbolKit",
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "SymbolKit",
             targets: ["SymbolKit"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SymbolKit",
             dependencies: []),
@@ -34,3 +27,10 @@ let package = Package(
             dependencies: ["SymbolKit"]),
     ]
 )
+
+// SwiftPM command plugins are only supported by Swift version 5.6 and later.
+#if swift(>=5.6)
+package.dependencies += [
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+]
+#endif

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ By modeling different kinds of relationships, SymbolKit can provide rich data to
 
 In addition, graph representations of data also present opportunities for visualizations in documentation, illustrating the structure or hierarchy of a module.
 
-## Getting Started Using Markup
+Please see SymbolKit's [documentation site](https://apple.github.io/swift-docc-symbolkit/documentation/symbolkit/) for more detailed information about the library.
+
+## Getting Started Using SymbolKit
 
 In your `Package.swift` Swift Package Manager manifest, add the following dependency to your `dependencies` argument:
 
@@ -26,7 +28,5 @@ Add the dependency to any targets you've declared in your manifest:
 ```swift
 .target(name: "MyTarget", dependencies: ["SymbolKit"]),
 ```
-
-Please see Swift `SymbolKit`'s [documentation site](https://apple.github.io/swift-docc-symbolkit/documentation/symbolkit/) for more detailed information about the library.
 
 <!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/README.md
+++ b/README.md
@@ -4,36 +4,6 @@ The specification and reference model for the *Symbol Graph* File Format.
 
 A *Symbol Graph* models a *module*, also known in various programming languages as a "framework", "library", or "package", as a [directed graph](https://en.wikipedia.org/wiki/Directed_graph). In this graph, the nodes are declarations, and the edges connecting nodes are relationships between declarations.
 
-To illustrate the shape of a symbol graph, take the following Swift code as a module called `MyModule`:
-
-```swift
-public struct MyStruct {
-  public var x: Int
-}
-```
-
-There are two nodes in this module's graph: the structure `MyStruct` and its property, `x`:
-
-![A graph with 2 nodes: "Struct Node" MyStruct and "Instance Property Node" x](Sources/SymbolKit/SymbolKit.docc/Resources/twonodes@2x.png)
-
-`x` is related to `MyStruct`: it is a *member* of `MyStruct`. SymbolKit represents *relationships* as directed edges in the graph:
-
-![Node x has a directed edge with text "memberof" to Node MyStruct](Sources/SymbolKit/SymbolKit.docc/Resources/member@2x.png)
-
-The *source* of an edge points to its *target*. You can read this edge as *`x` is a member of `MyStruct`*. Every edge is qualified by some kind of relationship; in this case, the kind is membership. There can be many kinds of relationships, even multiple relationships between the same two nodes. Here's another example, adding a Swift protocol to the mix:
-
-```swift
-public protocol P {}
-
-public struct MyStruct: P {
-  public var x: Int
-}
-```
-
-Now we've added a new node for the protocol `P`, and a new conformance relationship between `MyStruct` and `P`:
-
-![Node x has a directed edge with text "memberof" to Node MyStruct, Node MyStruct has a directed edge with text "conformsTo" to "Protocol Node" P](Sources/SymbolKit/SymbolKit.docc/Resources/conforms@2x.png)
-
 By modeling different kinds of relationships, SymbolKit can provide rich data to power documentation, answering interesting questions, such as:
 
 - *Which types conform to this protocol?*
@@ -43,4 +13,20 @@ By modeling different kinds of relationships, SymbolKit can provide rich data to
 
 In addition, graph representations of data also present opportunities for visualizations in documentation, illustrating the structure or hierarchy of a module.
 
-<!-- Copyright (c) 2021 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+## Getting Started Using Markup
+
+In your `Package.swift` Swift Package Manager manifest, add the following dependency to your `dependencies` argument:
+
+```swift
+.package(url: "https://github.com/apple/swift-docc-symbolkit.git", .branch("main")),
+```
+
+Add the dependency to any targets you've declared in your manifest:
+
+```swift
+.target(name: "MyTarget", dependencies: ["SymbolKit"]),
+```
+
+Please see Swift `SymbolKit`'s [documentation site](https://apple.github.io/swift-docc-symbolkit/documentation/symbolkit/) for more detailed information about the library.
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/Sources/SymbolKit/SymbolKit.docc/SymbolKit.md
+++ b/Sources/SymbolKit/SymbolKit.docc/SymbolKit.md
@@ -50,3 +50,5 @@ In addition, graph representations of data also present opportunities for visual
 ### Essentials
 
 - ``SymbolGraph``
+
+<!-- Copyright (c) 2021-2022 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/bin/check-source
+++ b/bin/check-source
@@ -38,7 +38,7 @@ fi
 printf "\033[0;32mokay.\033[0m\n"
 
 printf "=> Checking license headers… "
-tmp=$(mktemp /tmp/.swift-markdown-check-source_XXXXXX)
+tmp=$(mktemp /tmp/.swift-docc-symbolkit-check-source_XXXXXX)
 
 for language in swift-or-c bash md-or-tutorial html docker; do
   declare -a matching_files

--- a/bin/check-source
+++ b/bin/check-source
@@ -1,0 +1,152 @@
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+
+# This script performs code checks such as verifying that source files
+# use the correct license header. Its contents are largely copied from
+# https://github.com/apple/swift-nio/blob/main/scripts/soundness.sh
+
+set -eu
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function replace_acceptable_years() {
+    # this needs to replace all acceptable forms with 'YEARS'
+    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
+}
+
+printf "=> Checking for unacceptable language… "
+# This greps for unacceptable terminology. The square bracket[s] are so that
+# "git grep" doesn't find the lines that greps :).
+unacceptable_terms=(
+    -e blacklis[t]
+    -e whitelis[t]
+    -e slav[e]
+)
+
+if git grep --color=never -i "${unacceptable_terms[@]}" > /dev/null; then
+    printf "\033[0;31mUnacceptable language found.\033[0m\n"
+    git grep -i "${unacceptable_terms[@]}"
+    exit 1
+fi
+printf "\033[0;32mokay.\033[0m\n"
+
+printf "=> Checking license headers… "
+tmp=$(mktemp /tmp/.swift-markdown-check-source_XXXXXX)
+
+for language in swift-or-c bash md-or-tutorial html docker; do
+  declare -a matching_files
+  declare -a exceptions
+  declare -a reader
+  expections=( )
+  matching_files=( -name '*' )
+  reader=head
+  case "$language" in
+      swift-or-c)
+        exceptions=( -name 'Package*.swift')
+        matching_files=( -name '*.swift' -o -name '*.c' -o -name '*.h' )
+        cat > "$tmp" <<"EOF"
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) YEARS Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+EOF
+        ;;
+      bash)
+        matching_files=( -name '*.sh' )
+        cat > "$tmp" <<"EOF"
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) YEARS Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+EOF
+      ;;
+      md-or-tutorial)
+        exceptions=( -path "./.github/*.md")
+        matching_files=( -name '*.md' -o -name '*.tutorial' )
+        reader=tail
+        cat > "$tmp" <<"EOF"
+<!-- Copyright (c) YEARS Apple Inc and the Swift Project authors. All Rights Reserved. -->
+EOF
+      ;;
+      html)
+        matching_files=( -name '*.html' )
+        cat > "$tmp" <<"EOF"
+<!--
+  This source file is part of the Swift.org open source project
+
+  Copyright (c) YEARS Apple Inc. and the Swift project authors
+  Licensed under Apache License v2.0 with Runtime Library Exception
+
+  See https://swift.org/LICENSE.txt for license information
+  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+EOF
+      ;;
+      docker)
+        matching_files=( -name 'Dockerfile' )
+        cat > "$tmp" <<"EOF"
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) YEARS Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+EOF
+      ;;
+    *)
+      echo >&2 "ERROR: unknown language '$language'"
+      ;;
+  esac
+
+  # Determine which SHA command to use; not all platforms support shasum, but they
+  # likely either support shasum or sha256sum.
+  SHA_CMD=""
+  if [ -x "$(command -v shasum)" ]; then
+    SHA_CMD="shasum"
+  elif [ -x "$(command -v sha256sum)" ]; then
+    SHA_CMD="sha256sum"
+  else
+    echo >&2 "No sha command found; install shasum or sha256sum or submit a PR that supports another platform"
+  fi
+
+  expected_lines=$(cat "$tmp" | wc -l)
+  expected_sha=$(cat "$tmp" | "$SHA_CMD")
+
+  (
+    cd "$here/.."
+    find . \
+      \( \! -path './.build/*' -a \
+      \! -name '.' -a \
+      \( "${matching_files[@]}" \) -a \
+      \( \! \( "${exceptions[@]}" \) \) \) | while read line; do
+      if [[ "$(cat "$line" | replace_acceptable_years | $reader -n $expected_lines | $SHA_CMD)" != "$expected_sha" ]]; then
+        printf "\033[0;31mmissing headers in file '$line'!\033[0m\n"
+        diff -u <(cat "$line" | replace_acceptable_years | $reader -n $expected_lines) "$tmp"
+        exit 1
+      fi
+    done
+  )
+done
+
+printf "\033[0;32mokay.\033[0m\n"
+rm "$tmp"
+

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+
+set -eu
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+# First get the absolute path to this file so we can get the absolute file path to the SwiftMarkdown root source dir.
+SWIFT_DOCC_SYMBOLKIT_ROOT="$(dirname $(dirname $(filepath $0)))"
+
+# Build SwiftMarkdown.
+swift test --parallel --package-path "$SWIFT_DOCC_SYMBOLKIT_ROOT"
+
+# Run source code checks for the codebase.
+LC_ALL=C "$SWIFT_DOCC_SYMBOLKIT_ROOT"/bin/check-source
+
+# Test utility scripts validity.
+printf "=> Validating scripts in bin subdirectory… "
+
+printf "\033[0;32mokay.\033[0m\n"
+

--- a/bin/test
+++ b/bin/test
@@ -16,10 +16,10 @@ filepath() {
   [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
-# First get the absolute path to this file so we can get the absolute file path to the SwiftMarkdown root source dir.
+# First get the absolute path to this file so we can get the absolute file path to the SymbolKit root source dir.
 SWIFT_DOCC_SYMBOLKIT_ROOT="$(dirname $(dirname $(filepath $0)))"
 
-# Build SwiftMarkdown.
+# Build SymbolKit.
 swift test --parallel --package-path "$SWIFT_DOCC_SYMBOLKIT_ROOT"
 
 # Run source code checks for the codebase.

--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -24,9 +24,32 @@ filepath() {
 }
 
 SWIFT_DOCC_SYMBOLKIT_ROOT="$(dirname $(dirname $(filepath $0)))"
+SYMBOL_GRAPH_OUTPUT_DIR="$SWIFT_DOCC_SYMBOLKIT_ROOT/.build/swift-docc/symbol-graphs"
+
+mkdir -p "$SYMBOL_GRAPH_OUTPUT_DIR"
+rm -f "$SYMBOL_GRAPH_OUTPUT_DIR/*.*"
 
 # Set current directory to the repository root
 cd "$SWIFT_DOCC_SYMBOLKIT_ROOT"
+
+# On non-Darwin systems we expect the 'docc' command-line tool to be in the current path.
+# On Darwin, we expect 'docc' to be available via Xcode's 'xcrun'.
+DOCC_CMD=""
+if command -v xcrun &> /dev/null
+then
+    DOCC_CMD="xcrun docc"
+elif command -v docc &> /dev/null
+then
+    DOCC_CMD="docc"
+else
+    echo "Failed to find 'docc' or 'xcrun' in the current path."
+    exit 1
+fi
+
+# Generate symbol graph files for SymbolKit
+swift build --target SymbolKit \
+  -Xswiftc -emit-symbol-graph \
+  -Xswiftc -emit-symbol-graph-dir -Xswiftc "$SYMBOL_GRAPH_OUTPUT_DIR"
 
 # Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
 git fetch
@@ -37,13 +60,13 @@ export DOCC_JSON_PRETTYPRINT="YES"
 
 # Generate documentation for the 'SymbolKit' target and output it
 # to the /docs subdirectory in the gh-pages worktree directory.
-swift package \
-    --allow-writing-to-directory "$SWIFT_DOCC_SYMBOLKIT_ROOT/gh-pages/docs" \
-    generate-documentation \
-    --target SymbolKit \
-    --disable-indexing \
+$DOCC_CMD convert "$SWIFT_DOCC_SYMBOLKIT_ROOT/Sources/SymbolKit/SymbolKit.docc" \
+    --fallback-display-name SymbolKit \
+    --fallback-bundle-identifier org.swift.SymbolKit \
+    --fallback-bundle-version 1.0.0 \
     --transform-for-static-hosting \
     --hosting-base-path swift-docc-symbolkit \
+    --additional-symbol-graph-dir "$SYMBOL_GRAPH_OUTPUT_DIR" \
     --output-path "$SWIFT_DOCC_SYMBOLKIT_ROOT/gh-pages/docs"
 
 # Save the current commit we've just built documentation from in a variable

--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+#
+# Updates the GitHub Pages documentation site thats published from the 'docs' 
+# subdirectory in the 'gh-pages' branch of this repository.
+#
+# This script should be run by someone with commit access to the 'gh-pages' branch
+# at a regular frequency so that the documentation content on the GitHub Pages site
+# is up-to-date with the content in this repo.
+#
+
+set -eu
+
+# A `realpath` alternative using the default C implementation.
+filepath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+SWIFT_DOCC_SYMBOLKIT_ROOT="$(dirname $(dirname $(filepath $0)))"
+
+# Set current directory to the repository root
+cd "$SWIFT_DOCC_SYMBOLKIT_ROOT"
+
+# Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
+git fetch
+git worktree add --checkout gh-pages origin/gh-pages
+
+# Pretty print DocC JSON output so that it can be consistently diffed between commits
+export DOCC_JSON_PRETTYPRINT="YES"
+
+# Generate documentation for the 'SymbolKit' target and output it
+# to the /docs subdirectory in the gh-pages worktree directory.
+swift package \
+    --allow-writing-to-directory "$SWIFT_DOCC_SYMBOLKIT_ROOT/gh-pages/docs" \
+    generate-documentation \
+    --target SymbolKit \
+    --disable-indexing \
+    --transform-for-static-hosting \
+    --hosting-base-path swift-docc-symbolkit \
+    --output-path "$SWIFT_DOCC_SYMBOLKIT_ROOT/gh-pages/docs"
+
+# Save the current commit we've just built documentation from in a variable
+CURRENT_COMMIT_HASH=`git rev-parse --short HEAD`
+
+# Commit and push our changes to the gh-pages branch
+cd gh-pages
+git add docs
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Documentation changes found. Committing the changes to the 'gh-pages' branch and pushing to origin."
+    git commit -m "Update GitHub Pages documentation site to $CURRENT_COMMIT_HASH"
+    git push origin HEAD:gh-pages
+else
+    # No changes found, nothing to commit.
+    echo "No documentation changes found."
+fi
+
+# Delete the git worktree we created
+cd ..
+git worktree remove gh-pages


### PR DESCRIPTION
# Summary

This sets the foundation for deploying Swift SymbolKit's documentation to GitHub pages.

- Adds the [Swift-DocC Plugin](https://github.com/apple/swift-docc-plugin) as a dependency of Swift-SymbolKit.
- Adds a script to simplify deployment of documentation to GitHub pages.
- Adds check-source and test script and fix missing headers.
- Update README docs (Remove some duplication and add a link to the github page).
- Adds pull request template file as other swift-docc related repo.

After merging this PR, we should be able to prepare a `gh-pages` branch on the main `swift-docc-symbolkit` repo with no content on it, run the `bin/update-gh-pages-documentation-site` script and have docs available.

# Dependencies

None.

# Testing

With Swift 5.6, run:
```
swift package --disable-sandbox preview-documentation --target SymbolKit
```
and confirm the Swift-DocC preview works as expected.

# Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the ./bin/test script and it succeeded
- [x] Updated documentation if necessary

> Most of the content of this PR comes from @ethan-kusters. This is just a port for swift-docc-symbolkit repo.
> See more info here https://github.com/apple/swift-markdown/pull/32