### PR TITLE
Update SymbolKit.md's Swift demo code to 4 indent

### DIFF
--- a/Sources/SymbolKit/SymbolKit.docc/SymbolKit.md
+++ b/Sources/SymbolKit/SymbolKit.docc/SymbolKit.md
@@ -10,7 +10,7 @@ To illustrate the shape of a symbol graph, take the following Swift code as a mo
 
 ```swift
 public struct MyStruct {
-  public var x: Int
+    public var x: Int
 }
 ```
 
@@ -28,7 +28,7 @@ The *source* of an edge points to its *target*. You can read this edge as *`x` i
 public protocol P {}
 
 public struct MyStruct: P {
-  public var x: Int
+    public var x: Int
 }
 ```
 


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

Swift code prefer 4 space indent instead 2 space indent.

Update SymbolKit.md's Swift demo code to 4 indent.