### PR TITLE
add `ivar` and `macro` to the known symbol kinds

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,6 +23,8 @@ extension SymbolGraph.Symbol {
         case `func`
         case `operator`
         case `init`
+        case ivar
+        case macro
         case method
         case property
         case `protocol`
@@ -53,6 +55,8 @@ extension SymbolGraph.Symbol {
             case .func: return "func"
             case .operator: return "func.op"
             case .`init`: return "init"
+            case .ivar: return "ivar"
+            case .macro: return "macro"
             case .method: return "method"
             case .property: return "property"
             case .protocol: return "protocol"
@@ -86,6 +90,8 @@ extension SymbolGraph.Symbol {
             case "func": return .func
             case "func.op": return .operator
             case "init": return .`init`
+            case "ivar": return .ivar
+            case "macro": return .macro
             case "method": return .method
             case "property": return .property
             case "protocol": return .protocol

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/SymbolKindTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/SymbolKindTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -89,6 +89,16 @@ class SymbolKindTests: XCTestCase {
             XCTAssertNotNil(kind)
             XCTAssertEqual(kind.identifier, .func)
             XCTAssertEqual(kind.displayName, "Function")
+        }
+    }
+
+    /// Make sure that all the cases added to `KindIdentifier` can parse back as themselves
+    /// when their `identifier` string is given back to the `.init(identifier:)` initializer.
+    func testKindIdentifierRoundtrip() throws {
+        for identifier in SymbolGraph.Symbol.KindIdentifier.allCases {
+            let parsed = SymbolGraph.Symbol.KindIdentifier(identifier: identifier.identifier)
+
+            XCTAssertEqual(identifier, parsed)
         }
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://91166981

## Summary

To allow SymbolKit to load symbol graphs from the in-progress Clang symbol-graph support (cf. https://reviews.llvm.org/D122611 and https://reviews.llvm.org/D122446), two new symbol kinds need to be added: One for C preprocessor macros, and one for Objective-C interface variables. This PR also adds a new test that ensures that all the `KindIdentifier` cases can parse back as themselves, to ensure that the `.init(identifier:)` and `lookupIdentifier()` functions don't get out of sync.

## Dependencies

None

## Testing

The "ExtractAPI" symbol graph support in Clang is still experimental, but symbol graphs can be found as part of [the ExtractAPI tests](https://github.com/llvm/llvm-project/tree/main/clang/test/ExtractAPI) in the LLVM main branch. Loading either the `macros.c` output or the `objc_interface.m` output should result in a parsed `SymbolGraph` that has no `.unknown` symbols.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary