### PR TITLE
Enable library evolution via a conditional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ SymbolGraph.symbols.json
 .swiftpm
 Package.resolved
 .vscode
+.enable-library-evolution

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@
 */
 
 import PackageDescription
+import Foundation
 
 let package = Package(
     name: "SymbolKit",
@@ -23,9 +24,29 @@ let package = Package(
     targets: [
         .target(
             name: "SymbolKit",
-            dependencies: []),
+            dependencies: [],
+            swiftSettings: librarySwiftSettings()
+        ),
         .testTarget(
             name: "SymbolKitTests",
             dependencies: ["SymbolKit"]),
     ]
 )
+
+func librarySwiftSettings() -> [SwiftSetting]? {
+    let manifestLocation = URL(fileURLWithPath: #filePath)
+
+    let enableLibraryEvolutionFileLocation = manifestLocation
+        .deletingLastPathComponent()
+        .appendingPathComponent(".enable-library-evolution")
+    
+    // If there is a `.enable-library-evolution` file as a sibling of this package manifest
+    // build libraries with library evolution enabled.
+    if FileManager.default.fileExists(atPath: enableLibraryEvolutionFileLocation.path) {
+        return [
+            .unsafeFlags(["-enable-library-evolution"])
+        ]
+    } else {
+        return []
+    }
+}

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -10,6 +10,7 @@
 */
 
 import PackageDescription
+import Foundation
 
 let package = Package(
     name: "SymbolKit",
@@ -21,9 +22,29 @@ let package = Package(
     targets: [
         .target(
             name: "SymbolKit",
-            dependencies: []),
+            dependencies: [],
+            swiftSettings: librarySwiftSettings()
+        ),
         .testTarget(
             name: "SymbolKitTests",
             dependencies: ["SymbolKit"]),
     ]
 )
+
+func librarySwiftSettings() -> [SwiftSetting]? {
+    let manifestLocation = URL(fileURLWithPath: #filePath)
+
+    let enableLibraryEvolutionFileLocation = manifestLocation
+        .deletingLastPathComponent()
+        .appendingPathComponent(".enable-library-evolution")
+    
+    // If there is a `.enable-library-evolution` file as a sibling of this package manifest
+    // build libraries with library evolution enabled.
+    if FileManager.default.fileExists(atPath: enableLibraryEvolutionFileLocation.path) {
+        return [
+            .unsafeFlags(["-enable-library-evolution"])
+        ]
+    } else {
+        return []
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://91237393

## Summary

Adds support for building the `SymbolKit` library with library evolution enabled. This is disabled by default, and to enable the behavior, add an `.enable-library-evolution` file at the root of your checkout.

## Dependencies

None.

## Testing

Verify that `SymbolKit` is built with library evolution enabled by inspecting build logs if and only if the checkout has an `.enable-library-evolution` file at its root.

## Checklist

- ~[ ] Added tests~ N/A
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary