### PR TITLE
[5.7] add `ivar` and `macro` to known symbol kinds

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,6 +23,8 @@ extension SymbolGraph.Symbol {
         case `func`
         case `operator`
         case `init`
+        case ivar
+        case macro
         case method
         case property
         case `protocol`
@@ -53,6 +55,8 @@ extension SymbolGraph.Symbol {
             case .func: return "func"
             case .operator: return "func.op"
             case .`init`: return "init"
+            case .ivar: return "ivar"
+            case .macro: return "macro"
             case .method: return "method"
             case .property: return "property"
             case .protocol: return "protocol"
@@ -86,6 +90,8 @@ extension SymbolGraph.Symbol {
             case "func": return .func
             case "func.op": return .operator
             case "init": return .`init`
+            case "ivar": return .ivar
+            case "macro": return .macro
             case "method": return .method
             case "property": return .property
             case "protocol": return .protocol

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/SymbolKindTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/SymbolKindTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -89,6 +89,16 @@ class SymbolKindTests: XCTestCase {
             XCTAssertNotNil(kind)
             XCTAssertEqual(kind.identifier, .func)
             XCTAssertEqual(kind.displayName, "Function")
+        }
+    }
+
+    /// Make sure that all the cases added to `KindIdentifier` can parse back as themselves
+    /// when their `identifier` string is given back to the `.init(identifier:)` initializer.
+    func testKindIdentifierRoundtrip() throws {
+        for identifier in SymbolGraph.Symbol.KindIdentifier.allCases {
+            let parsed = SymbolGraph.Symbol.KindIdentifier(identifier: identifier.identifier)
+
+            XCTAssertEqual(identifier, parsed)
         }
     }
 }


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift-docc-symbolkit/pull/21 onto `release/5.7`.

**Explanation**: In preparation of allowing SymbolKit (and by proxy, Swift-DocC) to accept symbol graphs from Clang, this PR adds two new symbol kinds to the `KindIdentifier` enum: `ivar` (for Objective-C instance variables) and `macro` (for C preprocessor macros).

**Scope**: A low-impact change that shouldn't affect any existing uses of SymbolKit/Swift-DocC, and enables new ones.

**Radar**: rdar://91166981

**Risk**: Low. New `KindIdentifier` cases will not cause any existing workflows that use SymbolKit to change or be affected.

**Testing**: A new automated test has been added to ensure that symbol kinds can be parsed as themselves when serialized out and re-read. All existing automated tests still pass.