### PR TITLE
separate relationships by the graph they came from

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Relationship/Relationship.swift
+++ b/Sources/SymbolKit/SymbolGraph/Relationship/Relationship.swift
@@ -106,3 +106,30 @@ extension SymbolGraph {
         }
     }
 }
+
+extension SymbolGraph.Relationship: Hashable, Equatable {
+
+    /// A custom hashing for the relationship.
+    /// > Important: If there are new relationship mixins they need to be added to the hasher in this function.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(source)
+        hasher.combine(target)
+        hasher.combine(kind.rawValue)
+        hasher.combine(targetFallback)
+        hasher.combine(mixins[SymbolGraph.Relationship.Swift.GenericConstraints.mixinKey] as? Swift.GenericConstraints)
+        hasher.combine(mixins[SymbolGraph.Relationship.SourceOrigin.mixinKey] as? SourceOrigin)
+    }
+
+    /// A custom equality implmentation for a relationship.
+    /// > Important: If there are new relationship mixins they need to be added to the equality function.
+    public static func == (lhs: SymbolGraph.Relationship, rhs: SymbolGraph.Relationship) -> Bool {
+        return lhs.source == rhs.source
+            && lhs.target == rhs.target
+            && lhs.kind == rhs.kind
+            && lhs.targetFallback == rhs.targetFallback
+            && lhs.mixins[SymbolGraph.Relationship.Swift.GenericConstraints.mixinKey] as? Swift.GenericConstraints
+                == rhs.mixins[SymbolGraph.Relationship.Swift.GenericConstraints.mixinKey] as? Swift.GenericConstraints
+            && lhs.mixins[SymbolGraph.Relationship.SourceOrigin.mixinKey] as? SourceOrigin
+                == rhs.mixins[SymbolGraph.Relationship.SourceOrigin.mixinKey] as? SourceOrigin
+    }
+}

--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -77,7 +77,7 @@ extension GraphCollector {
         }
 
         for (_, graph) in self.unifiedGraphs {
-            graph.checkOrphans()
+            graph.collectOrphans()
         }
 
         return (self.unifiedGraphs, self.graphSources)

--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -76,6 +76,10 @@ extension GraphCollector {
             self.mergeSymbolGraph(graph, at: url, forceLoading: true)
         }
 
+        for (_, graph) in self.unifiedGraphs {
+            graph.checkOrphans()
+        }
+
         return (self.unifiedGraphs, self.graphSources)
     }
 

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
@@ -122,7 +122,15 @@ extension UnifiedSymbolGraph {
         return Array(map.values)
     }
 
-    internal func checkOrphans() {
+    /// Scans over ``orphanRelationships`` and sorts any whose source/target symbols were loaded
+    /// after the relationship was.
+    ///
+    /// Since relationships are added to ``relationshipsByLanguage`` based on what symbols are
+    /// available when the relationship is being loaded, a relationship can be considered an
+    /// "orphan" even when it's not, if the symbol graphs are loaded in a certain order. This
+    /// method was added to ensure that these relationships can be properly assigned a language
+    /// even if the symbol information isn't in the same symbol graph.
+    internal func collectOrphans() {
         var newRelations: [Selector: [SymbolGraph.Relationship]] = [:]
         var remainingOrphans: [SymbolGraph.Relationship] = []
         for rel in self.orphanRelationships {

--- a/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraphTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraphTests.swift
@@ -51,7 +51,7 @@ class UnifiedGraphTests: XCTestCase {
         let demoGraph = try XCTUnwrap(unifiedGraphs["DemoKit"])
 
         XCTAssertEqual(demoGraph.orphanRelationships.count, 1)
-        compareRelationships(demoGraph.orphanRelationships, [
+        XCTAssertEqual(demoGraph.orphanRelationships, [
             .init(
                 source: "unknownIdentifier",
                 target: "unknownProtocol",
@@ -112,18 +112,11 @@ private func compareRelationships(_ left: [SymbolGraph.Relationship], _ right: [
         }
     }
 
-    func assertRelations(_ l: SymbolGraph.Relationship, _ r: SymbolGraph.Relationship) {
-        XCTAssertEqual(l.source, r.source)
-        XCTAssertEqual(l.target, r.target)
-        XCTAssertEqual(l.kind, r.kind)
-        XCTAssertEqual(l.targetFallback, r.targetFallback)
-    }
-
     let leftSorted = left.sorted(by: compareRelations(_:_:))
     let rightSorted = right.sorted(by: compareRelations(_:_:))
 
     for (l, r) in zip(leftSorted, rightSorted) {
-        assertRelations(l, r)
+        XCTAssertEqual(l, r)
     }
 }
 

--- a/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraphTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraphTests.swift
@@ -1,0 +1,174 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Foundation
+@testable import SymbolKit
+
+class UnifiedGraphTests: XCTestCase {
+    /// Verify that ``UnifiedSymbolGraph`` sorts relationships correctly in the basic case.
+    func testUnifyRelations() throws {
+        let collector = GraphCollector()
+        collector.mergeSymbolGraph(swiftSymbolGraph(), at: .init(fileURLWithPath: "swift/DemoKit.symbols.json"))
+        collector.mergeSymbolGraph(objcSymbolGraph(), at: .init(fileURLWithPath: "objc/DemoKit.symbols.json"))
+
+        let (unifiedGraphs, _) = collector.finishLoading()
+        let demoGraph = try XCTUnwrap(unifiedGraphs["DemoKit"])
+
+        if let swiftRelations = demoGraph.relationshipsByLanguage.first(where: { $0.key.interfaceLanguage == "swift" })?.value {
+            compareRelationships(swiftRelations, swiftSymbolGraph().relationships)
+        } else {
+            XCTFail("Unified graph did not have swift relationships")
+        }
+
+        if let objcRelations = demoGraph.relationshipsByLanguage.first(where: { $0.key.interfaceLanguage == "objc" })?.value {
+            compareRelationships(objcRelations, objcSymbolGraph().relationships)
+        } else {
+            XCTFail("Unified graph did not have objc relationships")
+        }
+    }
+}
+
+/// Compare the given lists of relationships and assert that they contain the same relationships.
+private func compareRelationships(_ left: [SymbolGraph.Relationship], _ right: [SymbolGraph.Relationship]) {
+    func compareRelations(_ l: SymbolGraph.Relationship, _ r: SymbolGraph.Relationship) -> Bool {
+        if l.source < r.source {
+            return true
+        } else if l.source == r.source && l.target < r.target {
+            return true
+        } else if l.source == r.source && l.target == r.target && l.kind.rawValue < r.kind.rawValue {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    func assertRelations(_ l: SymbolGraph.Relationship, _ r: SymbolGraph.Relationship) {
+        XCTAssertEqual(l.source, r.source)
+        XCTAssertEqual(l.target, r.target)
+        XCTAssertEqual(l.kind, r.kind)
+        XCTAssertEqual(l.targetFallback, r.targetFallback)
+    }
+
+    let leftSorted = left.sorted(by: compareRelations(_:_:))
+    let rightSorted = right.sorted(by: compareRelations(_:_:))
+
+    for (l, r) in zip(leftSorted, rightSorted) {
+        assertRelations(l, r)
+    }
+}
+
+private func swiftSymbolGraph() -> SymbolGraph {
+    let symbols: [SymbolGraph.Symbol] = [
+        .init(
+            identifier: .init(precise: "c:objc(cs)PlayingCard", interfaceLanguage: "swift"),
+            names: .init(title: "PlayingCard", navigator: nil, subHeading: nil, prose: nil),
+            pathComponents: ["PlayingCard"],
+            docComment: nil,
+            accessLevel: .init(rawValue: "open"),
+            kind: .init(parsedIdentifier: .class, displayName: "Class"),
+            mixins: [:]
+        ),
+        .init(
+            identifier: .init(precise: "c:objc(pl)ColorDetecting", interfaceLanguage: "swift"),
+            names: .init(title: "ColorDetecting", navigator: nil, subHeading: nil, prose: nil),
+            pathComponents: ["ColorDetecting"],
+            docComment: nil,
+            accessLevel: .init(rawValue: "public"),
+            kind: .init(parsedIdentifier: .protocol, displayName: "Protocol"),
+            mixins: [:]
+        )
+    ]
+
+    let relations: [SymbolGraph.Relationship] = [
+        .init(
+            source: "c:objc(cs)PlayingCard",
+            target: "c:objc(pl)ColorDetecting",
+            kind: .conformsTo,
+            targetFallback: nil
+        ),
+        .init(
+            source: "c:objc(cs)PlayingCard",
+            target: "c:objc(pl)NSObject",
+            kind: .inheritsFrom,
+            targetFallback: "ObjectiveC.NSObject"
+        ),
+        .init(
+            source: "c:objc(cs)PlayingCard",
+            target: "s:SH",
+            kind: .conformsTo,
+            targetFallback: "Swift.Hashable"
+        )
+    ]
+
+    return makeSymbolGraph(symbols: symbols, relations: relations)
+}
+
+private func objcSymbolGraph() -> SymbolGraph {
+    let symbols: [SymbolGraph.Symbol] = [
+        .init(
+            identifier: .init(precise: "c:objc(cs)PlayingCard", interfaceLanguage: "objc"),
+            names: .init(title: "PlayingCard", navigator: nil, subHeading: nil, prose: nil),
+            pathComponents: ["PlayingCard"],
+            docComment: nil,
+            accessLevel: .init(rawValue: "public"),
+            kind: .init(parsedIdentifier: .class, displayName: "Class"),
+            mixins: [:]
+        ),
+        .init(
+            identifier: .init(precise: "c:objc(pl)ColorDetecting", interfaceLanguage: "objc"),
+            names: .init(title: "ColorDetecting", navigator: nil, subHeading: nil, prose: nil),
+            pathComponents: ["ColorDetecting"],
+            docComment: nil,
+            accessLevel: .init(rawValue: "public"),
+            kind: .init(parsedIdentifier: .protocol, displayName: "Protocol"),
+            mixins: [:]
+        )
+    ]
+
+    let relations: [SymbolGraph.Relationship] = [
+        .init(
+            source: "c:objc(cs)PlayingCard",
+            target: "c:objc(pl)ColorDetecting",
+            kind: .conformsTo,
+            targetFallback: nil
+        ),
+        .init(
+            source: "c:objc(cs)PlayingCard",
+            target: "c:objc(pl)NSObject",
+            kind: .inheritsFrom,
+            targetFallback: "NSObject"
+        )
+    ]
+
+    return makeSymbolGraph(symbols: symbols, relations: relations)
+}
+
+private func makeSymbolGraph(symbols: [SymbolGraph.Symbol], relations: [SymbolGraph.Relationship]) -> SymbolGraph {
+    let metadata = SymbolGraph.Metadata(
+        formatVersion: .init(major: 1, minor: 0, patch: 0),
+        generator: "unit-test"
+    )
+    let module = SymbolGraph.Module(
+        name: "DemoKit",
+        platform: .init(
+            architecture: "x86_64",
+            vendor: "apple",
+            operatingSystem: .init(name: "macosx"),
+            environment: nil
+        )
+    )
+    return SymbolGraph(
+        metadata: metadata,
+        module: module,
+        symbols: symbols,
+        relationships: relations
+    )
+}


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://91246013

## Summary

This PR updates the `UnifiedSymbolGraph` to also differentiate relationships by a `Selector`. Since relationships don't have an `interfaceLanguage` of their own, their respective symbols are searched to supply one. They are first searched in the graph being processed, then in the in-progress unified graph as a whole. The latter step is intended to catch protocol conformance on an external type when it's being loaded from an extension symbol graph.

## Dependencies

While the change was made in a way that preserved source compatibility, a corresponding change to Swift-DocC (https://github.com/apple/swift-docc/pull/304) is required to use the new information.

## Testing

A new test case is added to verify the relationship sorting behavior in a basic case. As end-to-end behavior is not fully implemented yet, a debugger and/or test project is required to observe the new behavior.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary