### PR TITLE
Revert "Revert "add `ivar` and `macro` to the known symbol kinds""

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -23,6 +23,8 @@ extension SymbolGraph.Symbol {
         case `func`
         case `operator`
         case `init`
+        case ivar
+        case macro
         case method
         case property
         case `protocol`
@@ -53,6 +55,8 @@ extension SymbolGraph.Symbol {
             case .func: return "func"
             case .operator: return "func.op"
             case .`init`: return "init"
+            case .ivar: return "ivar"
+            case .macro: return "macro"
             case .method: return "method"
             case .property: return "property"
             case .protocol: return "protocol"
@@ -86,6 +90,8 @@ extension SymbolGraph.Symbol {
             case "func": return .func
             case "func.op": return .operator
             case "init": return .`init`
+            case "ivar": return .ivar
+            case "macro": return .macro
             case "method": return .method
             case "property": return .property
             case "protocol": return .protocol

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/SymbolKindTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/SymbolKindTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -89,6 +89,16 @@ class SymbolKindTests: XCTestCase {
             XCTAssertNotNil(kind)
             XCTAssertEqual(kind.identifier, .func)
             XCTAssertEqual(kind.displayName, "Function")
+        }
+    }
+
+    /// Make sure that all the cases added to `KindIdentifier` can parse back as themselves
+    /// when their `identifier` string is given back to the `.init(identifier:)` initializer.
+    func testKindIdentifierRoundtrip() throws {
+        for identifier in SymbolGraph.Symbol.KindIdentifier.allCases {
+            let parsed = SymbolGraph.Symbol.KindIdentifier(identifier: identifier.identifier)
+
+            XCTAssertEqual(identifier, parsed)
         }
     }
 }


### PR DESCRIPTION
Reverts apple/swift-docc-symbolkit#24

This PR re-introduces #21, now that changes have been made to Swift-DocC (https://github.com/apple/swift-docc/pull/132) to allow it to land without breaking the build.