### PR TITLE
drop the Location mixin if it's malformed

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -187,7 +187,7 @@ extension SymbolGraph {
             case Availability.mixinKey:
                 return try container.decode(Availability.self, forKey: key)
             case Location.mixinKey:
-                return try container.decode(Location.self, forKey: key)
+                return try? container.decode(Location.self, forKey: key)
             case Mutability.mixinKey:
                 return try container.decode(Mutability.self, forKey: key)
             case FunctionSignature.mixinKey:


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://93797795

## Summary

In certain situations, symbol graphs can be generated with a `location` mixin which is missing its `position` field. Currently, this causes SymbolKit to crash. This PR tweaks the logic to instead drop the field if it fails to decode.

## Dependencies

None

## Testing

The following symbol graph contains symbols whose `location` mixin contains a `uri` but no `position`. This should be able to be loaded by SymbolKit without crashing after this change.

[DemoFramework.symbols.json.txt](https://github.com/apple/swift-docc-symbolkit/files/8758933/DemoFramework.symbols.json.txt)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary