### PR TITLE
[5.7] drop the Location mixin if it's malformed

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -187,7 +187,7 @@ extension SymbolGraph {
             case Availability.mixinKey:
                 return try container.decode(Availability.self, forKey: key)
             case Location.mixinKey:
-                return try container.decode(Location.self, forKey: key)
+                return try? container.decode(Location.self, forKey: key)
             case Mutability.mixinKey:
                 return try container.decode(Mutability.self, forKey: key)
             case FunctionSignature.mixinKey:

--- a/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
@@ -52,6 +52,58 @@ class SymbolTests: XCTestCase {
             XCTAssertNil(symbol.isDocCommentFromSameModule)
         }
     }
+
+    /// Check that a Location mixin without position information still decodes a symbol graph without throwing.
+    func testMalformedLocationDoesNotThrow() throws {
+        let inputGraph = """
+{
+  "accessLevel" : "public",
+  "kind" : {
+    "displayName" : "Instance Method",
+    "identifier" : "swift.method"
+  },
+  "pathComponents" : [
+    "ClassName",
+    "something()"
+  ],
+  "identifier" : {
+    "precise" : "precise-identifier",
+    "interfaceLanguage" : "swift"
+  },
+  "names" : {
+    "title" : "something()"
+  },
+  "location" : {
+    "uri" : "file:///path/to/someSource.swift"
+  },
+  "declarationFragments" : [
+    {
+      "kind" : "keyword",
+      "spelling" : "func"
+    },
+    {
+      "kind" : "text",
+      "spelling" : " "
+    },
+    {
+      "kind" : "identifier",
+      "spelling" : "something"
+    },
+    {
+      "kind" : "text",
+      "spelling" : "() -> "
+    },
+    {
+      "kind" : "keyword",
+      "spelling" : "Any"
+    }
+  ]
+}
+""".data(using: .utf8)!
+
+        let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: inputGraph)
+        XCTAssertNil(symbol.mixins[SymbolGraph.Symbol.Location.mixinKey])
+    }
     
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-docc-symbolkit/pull/33

**Explanation**: This PR allows SymbolKit to be more resilient against malformed symbol graphs by dropping the Location mixin if it fails to decode.

**Scope**: Allows more symbol graphs to be accepted by SymbolKit by discarding incomplete information.

**Radar**: rdar://93797795

**Risk**: Very low. The Location mixin is optional to begin with, and clients like Swift-DocC are already capable of handling symbols without location information.

**Testing**: A new automated test has been added to ensure that a symbol graph with an incomplete Location mixin can still decode without throwing an exception. All existing automated tests still pass.