### PR TITLE
Decode the new docComment module and file information

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/LineList/LineList.swift
+++ b/Sources/SymbolKit/SymbolGraph/LineList/LineList.swift
@@ -1,12 +1,14 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
+
+import Foundation
 
 extension SymbolGraph {
     /**
@@ -91,9 +93,21 @@ extension SymbolGraph {
     public struct LineList: Codable, Equatable {
         /// The lines making up this line list.
         public var lines: [Line]
-
-        public init(_ lines: [Line]) {
+        /// The file URL of the source file where the documentation comment originated.
+        public var url: URL?
+        /// The name of the source module where the documentation comment originated.
+        public var moduleName: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case lines
+            case url = "uri"
+            case moduleName = "module"
+        }
+        
+        public init(_ lines: [Line], url: URL? = nil, moduleName: String? = nil) {
             self.lines = lines
+            self.url = url
+            self.moduleName = moduleName
         }
 
         /**

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -58,7 +58,12 @@ extension SymbolGraph {
         /// the same module as the symbol or not.
         ///
         /// An inherited documentation comment is from the same module when the symbol that the documentation is inherited from is in the same module as this symbol.
+        @available(*, deprecated, message: "Use 'docComment?.moduleName' instead to compare the documentation's source module name with another module name.")
         public var isDocCommentFromSameModule: Bool? {
+            _isDocCommentFromSameModule
+        }
+        // To avoid deprecation warnings in SymbolKit test until the deprecated property is removed.
+        internal var _isDocCommentFromSameModule: Bool? {
             guard let docComment = docComment, !docComment.lines.isEmpty else {
                 return nil
             }

--- a/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
@@ -20,6 +20,7 @@ class SymbolTests: XCTestCase {
             let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: jsonData)
 
             XCTAssertNil(symbol._isDocCommentFromSameModule)
+            XCTAssertNil(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"))
         }
         
         // without range information
@@ -30,6 +31,7 @@ class SymbolTests: XCTestCase {
             let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: jsonData)
 
             XCTAssertEqual(symbol._isDocCommentFromSameModule, false)
+            XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"), false)
         }
         
         // with range information
@@ -40,6 +42,7 @@ class SymbolTests: XCTestCase {
             let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: jsonData)
 
             XCTAssertEqual(symbol._isDocCommentFromSameModule, true)
+            XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"), true)
         }
         
         // empty doc comment
@@ -50,6 +53,7 @@ class SymbolTests: XCTestCase {
             let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: jsonData)
 
             XCTAssertNil(symbol._isDocCommentFromSameModule)
+            XCTAssertNil(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"))
         }
     }
     
@@ -62,6 +66,9 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(symbol.docComment?.moduleName, "ModuleName")
         XCTAssertEqual(symbol.docComment?.url?.isFileURL, true)
         XCTAssertEqual(symbol.docComment?.url?.pathComponents.last, "file name")
+        
+        XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "ModuleName"), true)
+        XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"), false)
     }
 
     /// Check that a Location mixin without position information still decodes a symbol graph without throwing.


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://92185538

## Summary

This decodes the new `module` and `uri` properties for `docComment` that were added in https://github.com/apple/swift/pull/58857

## Dependencies

This data is only available with https://github.com/apple/swift/pull/58857 

These properties will be `nil` if the symbol graph doesn't contain the new information.

## Testing

- Decode a symbol graph file that was created with a recent trunk toolchain. 
- Check that the symbol graph file contains "module" and "uri" fields for some documentation comments. 
- The decoded symbols should have source module name information and source file URL information. 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary