### PR TITLE
[5.7] Decode the new docComment module and file information

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/LineList/LineList.swift
+++ b/Sources/SymbolKit/SymbolGraph/LineList/LineList.swift
@@ -93,20 +93,33 @@ extension SymbolGraph {
     public struct LineList: Codable, Equatable {
         /// The lines making up this line list.
         public var lines: [Line]
+        
+        /// The URI of the source file where the documentation comment originated.
+        public var uri: String?
+        
         /// The file URL of the source file where the documentation comment originated.
-        public var url: URL?
+        @available(macOS 10.11, *)
+        public var url: URL? {
+            guard let uri = uri else { return nil }
+            // The URI string provided in the symbol graph file may be an invalid URL (rdar://69242070)
+            //
+            // Using `URL.init(dataRepresentation:relativeTo:)` here handles URI strings with unescaped
+            // characters without trying to escape or otherwise process the URI string in SymbolKit.
+            return URL(dataRepresentation: Data(uri.utf8), relativeTo: nil)
+        }
+        
         /// The name of the source module where the documentation comment originated.
         public var moduleName: String?
         
         enum CodingKeys: String, CodingKey {
             case lines
-            case url = "uri"
+            case uri
             case moduleName = "module"
         }
         
-        public init(_ lines: [Line], url: URL? = nil, moduleName: String? = nil) {
+        public init(_ lines: [Line], uri: String? = nil, moduleName: String? = nil) {
             self.lines = lines
-            self.url = url
+            self.uri = uri
             self.moduleName = moduleName
         }
 

--- a/Sources/SymbolKit/SymbolGraph/LineList/LineList.swift
+++ b/Sources/SymbolKit/SymbolGraph/LineList/LineList.swift
@@ -1,12 +1,14 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
  See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
+
+import Foundation
 
 extension SymbolGraph {
     /**
@@ -91,9 +93,21 @@ extension SymbolGraph {
     public struct LineList: Codable, Equatable {
         /// The lines making up this line list.
         public var lines: [Line]
-
-        public init(_ lines: [Line]) {
+        /// The file URL of the source file where the documentation comment originated.
+        public var url: URL?
+        /// The name of the source module where the documentation comment originated.
+        public var moduleName: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case lines
+            case url = "uri"
+            case moduleName = "module"
+        }
+        
+        public init(_ lines: [Line], url: URL? = nil, moduleName: String? = nil) {
             self.lines = lines
+            self.url = url
+            self.moduleName = moduleName
         }
 
         /**

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Location.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Location.swift
@@ -27,6 +27,18 @@ extension SymbolGraph.Symbol {
         public var uri: String
 
         /**
+         The file URL of the source file where the symbol was originally declared.
+         */
+        @available(macOS 10.11, *)
+        public var url: URL? {
+            // The URI string provided in the symbol graph file may be an invalid URL (rdar://69242070)
+            //
+            // Using `URL.init(dataRepresentation:relativeTo:)` here handles URI strings with unescaped
+            // characters without trying to escape or otherwise process the URI string in SymbolKit.
+            URL(dataRepresentation: Data(uri.utf8), relativeTo: nil)
+        }
+        
+        /**
          The range of the declaration in the file, not including its documentation comment.
          */
         public var position: SymbolGraph.LineList.SourceRange.Position

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -58,7 +58,12 @@ extension SymbolGraph {
         /// the same module as the symbol or not.
         ///
         /// An inherited documentation comment is from the same module when the symbol that the documentation is inherited from is in the same module as this symbol.
+        @available(*, deprecated, message: "Use 'isDocCommentFromSameModule(symbolModuleName:)' instead.")
         public var isDocCommentFromSameModule: Bool? {
+            _isDocCommentFromSameModule
+        }
+        // To avoid deprecation warnings in SymbolKit test until the deprecated property is removed.
+        internal var _isDocCommentFromSameModule: Bool? {
             guard let docComment = docComment, !docComment.lines.isEmpty else {
                 return nil
             }
@@ -66,8 +71,29 @@ extension SymbolGraph {
             // As a current implementation detail, documentation comments from within the current module has range information but
             // documentation comments that are inherited from other modules don't have any range information.
             //
-            // It would be better for correctness and accuracy to determine this when extracting the symbol information (rdar://81190369)
+            // This isn't always correct and is only used as a fallback logic for symbol information before the source module was
+            // included in the symbol graph file.
             return docComment.lines.contains(where: { $0.range != nil })
+        }
+        
+        /// If the symbol has a documentation comment, checks whether the documentation comment is from the same module as the symbol.
+        ///
+        /// A documentation comment is from the same module as the symbol when the source of the documentation comment is the symbol itself or another symbol in the same module.
+        ///
+        /// - Parameter symbolModuleName: The name of the module where the symbol is defined.
+        /// - Returns: `true`if the source of the documentation comment is from the same module as this symbol.
+        public func isDocCommentFromSameModule(symbolModuleName: String) -> Bool? {
+            guard let docComment = docComment, !docComment.lines.isEmpty else {
+                return nil
+            }
+            
+            if let moduleName = docComment.moduleName {
+                // If the new source module information is available, rely on that.
+                return moduleName == symbolModuleName
+            } else {
+                // Otherwise, fallback to the previous implementation.
+                return _isDocCommentFromSameModule
+            }
         }
 
         /// The access level of the symbol.

--- a/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
@@ -70,6 +70,117 @@ class SymbolTests: XCTestCase {
         XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "ModuleName"), true)
         XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"), false)
     }
+    
+    func testURIStringsThatAreNotValidURLs() throws {
+        let uris = [
+            "filename.swift",
+            "relative/path/to/filename.swift",
+            "/absolute/path/to/filename.swift",
+            "file:///absolute/path/to/filename.swift",
+            
+            "relative/path with spaces/to/filename.swift",
+            "/absolute/path with spaces/to/filename.swift",
+            "file:///absolute/path with spaces/to/filename.swift",
+            
+            "filename with spaces.swift",
+            "relative/path/to/filename with spaces.swift",
+            "/absolute/path/to/filename with spaces.swift",
+            "file:///absolute/path/to/filename with spaces.swift",
+            
+            "filename%20with%20escaped%20spaces.swift",
+            "relative/path/to/filename%20with%20escaped%20spaces.swift",
+            "/absolute/path/to/filename%20with%20escaped%20spaces.swift",
+            "file:///absolute/path/to/filename%20with%20escaped%20spaces.swift",
+        ]
+        
+        for uri in uris {
+            let inputGraph = """
+{
+  "accessLevel" : "public",
+  "kind" : {
+    "displayName" : "Instance Method",
+    "identifier" : "swift.method"
+  },
+  "pathComponents" : [
+    "ClassName",
+    "something()"
+  ],
+  "identifier" : {
+    "precise" : "precise-identifier",
+    "interfaceLanguage" : "swift"
+  },
+  "names" : {
+    "title" : "something()"
+  },
+  "location" : {
+    "position" : {
+      "character" : 4,
+      "line" : 3
+    },
+    "uri" : "\(uri)"
+  },
+  "docComment" : {
+    "lines" : [
+      {
+        "range" : {
+          "end" : {
+            "character" : 21,
+            "line": 2
+          },
+          "start" : {
+            "character" : 4,
+            "line" : 2
+          }
+        },
+        "text" : "Doc comment text."
+      }
+    ],
+    "module" : "SourceModuleName",
+    "uri" : "\(uri)"
+  },
+  "declarationFragments" : [
+    {
+      "kind" : "keyword",
+      "spelling" : "func"
+    },
+    {
+      "kind" : "text",
+      "spelling" : " "
+    },
+    {
+      "kind" : "identifier",
+      "spelling" : "something"
+    },
+    {
+      "kind" : "text",
+      "spelling" : "() -> "
+    },
+    {
+      "kind" : "keyword",
+      "spelling" : "Any"
+    }
+  ]
+}
+""".data(using: .utf8)!
+            
+            let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: inputGraph)
+            
+            // This doesn't do full percent encoding to preserve the "file://" prefix.
+            let expectedAbsoluteURLString = uri.replacingOccurrences(of: " ", with: "%20")
+            
+            let docComment = try XCTUnwrap(symbol.docComment)
+            XCTAssertEqual(docComment.uri, uri)
+            XCTAssertNotNil(docComment.url)
+            XCTAssertEqual(false, docComment.url?.path.contains("%20"))
+            XCTAssertEqual(docComment.url?.absoluteString, expectedAbsoluteURLString)
+            
+            let location = try XCTUnwrap(symbol.mixins[SymbolGraph.Symbol.Location.mixinKey] as? SymbolGraph.Symbol.Location)
+            XCTAssertEqual(location.uri, uri)
+            XCTAssertNotNil(location.url)
+            XCTAssertEqual(false, location.url?.path.contains("%20"))
+            XCTAssertEqual(location.url?.absoluteString, expectedAbsoluteURLString)
+        }
+    }
 
     /// Check that a Location mixin without position information still decodes a symbol graph without throwing.
     func testMalformedLocationDoesNotThrow() throws {
@@ -138,7 +249,7 @@ private func encodedSymbol(withDocComment: (lines: [String], rangeStart: (line: 
                 )
             }
             return SymbolGraph.LineList.Line(text: text, range: range)
-        }, url: withDocComment.fileName.map({ URL(fileURLWithPath: $0) }), moduleName: withDocComment.moduleName)
+        }, uri: withDocComment.fileName.map({ "file:///path/to/" + $0 }), moduleName: withDocComment.moduleName)
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
         let data = try! encoder.encode(lineList)

--- a/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -19,38 +19,56 @@ class SymbolTests: XCTestCase {
             let jsonData = encodedSymbol(withDocComment: nil).data(using: .utf8)!
             let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: jsonData)
 
-            XCTAssertNil(symbol.isDocCommentFromSameModule)
+            XCTAssertNil(symbol._isDocCommentFromSameModule)
+            XCTAssertNil(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"))
         }
         
         // without range information
         do {
             let jsonData = encodedSymbol(withDocComment:
-                (lines: ["First line", "Second line"], rangeStart: nil)
+                (lines: ["First line", "Second line"], rangeStart: nil, moduleName: nil, fileName: nil)
             ).data(using: .utf8)!
             let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: jsonData)
 
-            XCTAssertEqual(symbol.isDocCommentFromSameModule, false)
+            XCTAssertEqual(symbol._isDocCommentFromSameModule, false)
+            XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"), false)
         }
         
         // with range information
         do {
             let jsonData = encodedSymbol(withDocComment:
-                (lines: ["First line", "Second line"], rangeStart: (line: 2, character: 4))
+                (lines: ["First line", "Second line"], rangeStart: (line: 2, character: 4), moduleName: nil, fileName: nil)
             ).data(using: .utf8)!
             let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: jsonData)
 
-            XCTAssertEqual(symbol.isDocCommentFromSameModule, true)
+            XCTAssertEqual(symbol._isDocCommentFromSameModule, true)
+            XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"), true)
         }
         
         // empty doc comment
         do {
             let jsonData = encodedSymbol(withDocComment:
-                (lines: [], rangeStart: (line: 2, character: 4))
+                (lines: [], rangeStart: (line: 2, character: 4), moduleName: nil, fileName: nil)
             ).data(using: .utf8)!
             let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: jsonData)
 
-            XCTAssertNil(symbol.isDocCommentFromSameModule)
+            XCTAssertNil(symbol._isDocCommentFromSameModule)
+            XCTAssertNil(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"))
         }
+    }
+    
+    func testDocCommentModuleInformation() throws {
+        let jsonData = encodedSymbol(withDocComment:
+            (lines: ["First line", "Second line"], rangeStart: nil, moduleName: "ModuleName", fileName: "file name")
+        ).data(using: .utf8)!
+        let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: jsonData)
+
+        XCTAssertEqual(symbol.docComment?.moduleName, "ModuleName")
+        XCTAssertEqual(symbol.docComment?.url?.isFileURL, true)
+        XCTAssertEqual(symbol.docComment?.url?.pathComponents.last, "file name")
+        
+        XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "ModuleName"), true)
+        XCTAssertEqual(symbol.isDocCommentFromSameModule(symbolModuleName: "Test"), false)
     }
 
     /// Check that a Location mixin without position information still decodes a symbol graph without throwing.
@@ -109,8 +127,7 @@ class SymbolTests: XCTestCase {
 
 // MARK: Test Data
 
-private func encodedSymbol(withDocComment: (lines: [String], rangeStart: (line: Int, character: Int)?)?) -> String {
-    
+private func encodedSymbol(withDocComment: (lines: [String], rangeStart: (line: Int, character: Int)?, moduleName: String?, fileName: String?)?) -> String {
     let docCommentJSON: String
     if let withDocComment = withDocComment {
         let lineList = SymbolGraph.LineList(withDocComment.lines.enumerated().map { index, text in
@@ -121,7 +138,7 @@ private func encodedSymbol(withDocComment: (lines: [String], rangeStart: (line: 
                 )
             }
             return SymbolGraph.LineList.Line(text: text, range: range)
-        })
+        }, url: withDocComment.fileName.map({ URL(fileURLWithPath: $0) }), moduleName: withDocComment.moduleName)
         let encoder = JSONEncoder()
         encoder.outputFormatting = .prettyPrinted
         let data = try! encoder.encode(lineList)


### PR DESCRIPTION
- **Rationale:** This is—together with the two other parts—fix an issue where documentation comments that are inherited from other modules may raise non-actionable warnings if the original documentation comment linked to other symbols in that module.
- **Risk:** Low
- **Risk Detail:** The improved method for checking the origin of a documentation comment is added as new API. 
- **Reward:** Medium
- **Reward Details:** Documentation builds successfully but documentation for protocol conformance symbols from other modules may render with broken links to symbols.
- **Original PR:** #42 
- **Issue:** rdar://92185538
- **Code Reviewed By:** @QuietMisdreavus 
- **Testing Details:** See https://github.com/apple/swift-docc/pull/314
