### PR TITLE
Adapt Symbol Graph Format to Changes Introduced in apple/swift#59047

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Relationship/RelationshipKind.swift
+++ b/Sources/SymbolKit/SymbolGraph/Relationship/RelationshipKind.swift
@@ -83,5 +83,16 @@ extension SymbolGraph.Relationship {
          an interface `B` has an optional requirement of `A`.
          */
         public static let optionalRequirementOf = Kind(rawValue: "optionalRequirementOf")
+        
+        /**
+         A symbol `A` extends a symbol `B` with members or conformances.
+
+         This relationship describes the connection between extension blocks
+         (swift.extension symbols) and the type they extend.
+
+         The implied inverse of this relationship is a symbol `B` that is extended
+         by an extension block symbol `A`.
+         */
+        public static let extensionTo = Kind(rawValue: "extensionTo")
     }
 }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -39,6 +39,8 @@ extension SymbolGraph.Symbol {
         case `var`
 
         case module
+        
+        case `extension`
 
         case unknown
 
@@ -70,6 +72,7 @@ extension SymbolGraph.Symbol {
             case .typealias: return "typealias"
             case .var: return "var"
             case .module: return "module"
+            case .extension: return "extension"
             case .unknown: return "unknown"
             }
         }
@@ -105,6 +108,7 @@ extension SymbolGraph.Symbol {
             case "typealias": return .typealias
             case "var": return .var
             case "module": return .module
+            case "extension": return .extension
             default: return nil
             }
         }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Swift/Extension.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Swift/Extension.swift
@@ -25,24 +25,37 @@ extension SymbolGraph.Symbol.Swift {
         public var extendedModule: String
 
         /**
+         The ``SymbolGraph/Symbol/KindIdentifier`` of the symbol this
+         extension extends.
+          
+         Usually, this will be either of ``SymbolGraph/Symbol/KindIdentifier/struct``,
+         ``SymbolGraph/Symbol/KindIdentifier/class``, ``SymbolGraph/Symbol/KindIdentifier/enum``
+         or ``SymbolGraph/Symbol/KindIdentifier/protocol``.
+         */
+        public var typeKind: SymbolGraph.Symbol.KindIdentifier?
+        
+        /**
          The generic constraints on the extension, if any.
          */
         public var constraints: [GenericConstraint]
 
         enum CodingKeys: String, CodingKey {
             case extendedModule
+            case typeKind
             case constraints
         }
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             extendedModule = try container.decode(String.self, forKey: .extendedModule)
+            typeKind = try container.decodeIfPresent(SymbolGraph.Symbol.KindIdentifier.self, forKey: .typeKind)
             constraints = try container.decodeIfPresent([GenericConstraint].self, forKey: .constraints) ?? []
         }
 
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(extendedModule, forKey: .extendedModule)
+            try container.encodeIfPresent(typeKind, forKey: .typeKind)
             if !constraints.isEmpty {
                 try container.encode(constraints, forKey: .constraints)
             }

--- a/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
@@ -95,73 +95,73 @@ class SymbolTests: XCTestCase {
         
         for uri in uris {
             let inputGraph = """
-{
-  "accessLevel" : "public",
-  "kind" : {
-    "displayName" : "Instance Method",
-    "identifier" : "swift.method"
-  },
-  "pathComponents" : [
-    "ClassName",
-    "something()"
-  ],
-  "identifier" : {
-    "precise" : "precise-identifier",
-    "interfaceLanguage" : "swift"
-  },
-  "names" : {
-    "title" : "something()"
-  },
-  "location" : {
-    "position" : {
-      "character" : 4,
-      "line" : 3
-    },
-    "uri" : "\(uri)"
-  },
-  "docComment" : {
-    "lines" : [
-      {
-        "range" : {
-          "end" : {
-            "character" : 21,
-            "line": 2
-          },
-          "start" : {
-            "character" : 4,
-            "line" : 2
-          }
-        },
-        "text" : "Doc comment text."
-      }
-    ],
-    "module" : "SourceModuleName",
-    "uri" : "\(uri)"
-  },
-  "declarationFragments" : [
-    {
-      "kind" : "keyword",
-      "spelling" : "func"
-    },
-    {
-      "kind" : "text",
-      "spelling" : " "
-    },
-    {
-      "kind" : "identifier",
-      "spelling" : "something"
-    },
-    {
-      "kind" : "text",
-      "spelling" : "() -> "
-    },
-    {
-      "kind" : "keyword",
-      "spelling" : "Any"
-    }
-  ]
-}
-""".data(using: .utf8)!
+            {
+              "accessLevel" : "public",
+              "kind" : {
+                "displayName" : "Instance Method",
+                "identifier" : "swift.method"
+              },
+              "pathComponents" : [
+                "ClassName",
+                "something()"
+              ],
+              "identifier" : {
+                "precise" : "precise-identifier",
+                "interfaceLanguage" : "swift"
+              },
+              "names" : {
+                "title" : "something()"
+              },
+              "location" : {
+                "position" : {
+                  "character" : 4,
+                  "line" : 3
+                },
+                "uri" : "\(uri)"
+              },
+              "docComment" : {
+                "lines" : [
+                  {
+                    "range" : {
+                      "end" : {
+                        "character" : 21,
+                        "line": 2
+                      },
+                      "start" : {
+                        "character" : 4,
+                        "line" : 2
+                      }
+                    },
+                    "text" : "Doc comment text."
+                  }
+                ],
+                "module" : "SourceModuleName",
+                "uri" : "\(uri)"
+              },
+              "declarationFragments" : [
+                {
+                  "kind" : "keyword",
+                  "spelling" : "func"
+                },
+                {
+                  "kind" : "text",
+                  "spelling" : " "
+                },
+                {
+                  "kind" : "identifier",
+                  "spelling" : "something"
+                },
+                {
+                  "kind" : "text",
+                  "spelling" : "() -> "
+                },
+                {
+                  "kind" : "keyword",
+                  "spelling" : "Any"
+                }
+              ]
+            }
+            """.data(using: .utf8)!
             
             let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: inputGraph)
             
@@ -185,50 +185,50 @@ class SymbolTests: XCTestCase {
     /// Check that a Location mixin without position information still decodes a symbol graph without throwing.
     func testMalformedLocationDoesNotThrow() throws {
         let inputGraph = """
-{
-  "accessLevel" : "public",
-  "kind" : {
-    "displayName" : "Instance Method",
-    "identifier" : "swift.method"
-  },
-  "pathComponents" : [
-    "ClassName",
-    "something()"
-  ],
-  "identifier" : {
-    "precise" : "precise-identifier",
-    "interfaceLanguage" : "swift"
-  },
-  "names" : {
-    "title" : "something()"
-  },
-  "location" : {
-    "uri" : "file:///path/to/someSource.swift"
-  },
-  "declarationFragments" : [
-    {
-      "kind" : "keyword",
-      "spelling" : "func"
-    },
-    {
-      "kind" : "text",
-      "spelling" : " "
-    },
-    {
-      "kind" : "identifier",
-      "spelling" : "something"
-    },
-    {
-      "kind" : "text",
-      "spelling" : "() -> "
-    },
-    {
-      "kind" : "keyword",
-      "spelling" : "Any"
-    }
-  ]
-}
-""".data(using: .utf8)!
+        {
+          "accessLevel" : "public",
+          "kind" : {
+            "displayName" : "Instance Method",
+            "identifier" : "swift.method"
+          },
+          "pathComponents" : [
+            "ClassName",
+            "something()"
+          ],
+          "identifier" : {
+            "precise" : "precise-identifier",
+            "interfaceLanguage" : "swift"
+          },
+          "names" : {
+            "title" : "something()"
+          },
+          "location" : {
+            "uri" : "file:///path/to/someSource.swift"
+          },
+          "declarationFragments" : [
+            {
+              "kind" : "keyword",
+              "spelling" : "func"
+            },
+            {
+              "kind" : "text",
+              "spelling" : " "
+            },
+            {
+              "kind" : "identifier",
+              "spelling" : "something"
+            },
+            {
+              "kind" : "text",
+              "spelling" : "() -> "
+            },
+            {
+              "kind" : "keyword",
+              "spelling" : "Any"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
 
         let symbol = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: inputGraph)
         XCTAssertNil(symbol.mixins[SymbolGraph.Symbol.Location.mixinKey])
@@ -237,51 +237,51 @@ class SymbolTests: XCTestCase {
     /// Check that an Extension mixin keeps the `typeKind` information if available and doesn't throw if it is absent.
     func testOptionalExtensionTypeKindCoding() throws {
         let inputGraphWithTypeKindInformation = """
-{
-  "accessLevel" : "public",
-  "kind" : {
-    "displayName" : "Instance Method",
-    "identifier" : "swift.method"
-  },
-  "pathComponents" : [
-    "ClassName",
-    "something()"
-  ],
-  "identifier" : {
-    "precise" : "precise-identifier",
-    "interfaceLanguage" : "swift"
-  },
-  "names" : {
-    "title" : "something()"
-  },
-  "swiftExtension": {
-    "extendedModule": "ExtendedModule",
-    "typeKind": "class"
-  },
-  "declarationFragments" : [
-    {
-      "kind" : "keyword",
-      "spelling" : "func"
-    },
-    {
-      "kind" : "text",
-      "spelling" : " "
-    },
-    {
-      "kind" : "identifier",
-      "spelling" : "something"
-    },
-    {
-      "kind" : "text",
-      "spelling" : "() -> "
-    },
-    {
-      "kind" : "keyword",
-      "spelling" : "Any"
-    }
-  ]
-}
-""".data(using: .utf8)!
+        {
+          "accessLevel" : "public",
+          "kind" : {
+            "displayName" : "Instance Method",
+            "identifier" : "swift.method"
+          },
+          "pathComponents" : [
+            "ClassName",
+            "something()"
+          ],
+          "identifier" : {
+            "precise" : "precise-identifier",
+            "interfaceLanguage" : "swift"
+          },
+          "names" : {
+            "title" : "something()"
+          },
+          "swiftExtension": {
+            "extendedModule": "ExtendedModule",
+            "typeKind": "class"
+          },
+          "declarationFragments" : [
+            {
+              "kind" : "keyword",
+              "spelling" : "func"
+            },
+            {
+              "kind" : "text",
+              "spelling" : " "
+            },
+            {
+              "kind" : "identifier",
+              "spelling" : "something"
+            },
+            {
+              "kind" : "text",
+              "spelling" : "() -> "
+            },
+            {
+              "kind" : "keyword",
+              "spelling" : "Any"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
     
         let symbolWithTypeKind = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: inputGraphWithTypeKindInformation)
         XCTAssertNotNil((symbolWithTypeKind.mixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] as? SymbolGraph.Symbol.Swift.Extension)?.typeKind)
@@ -289,50 +289,50 @@ class SymbolTests: XCTestCase {
         XCTAssertTrue(String(data: try JSONEncoder().encode(symbolWithTypeKind), encoding: .utf8)!.contains("\"typeKind\":\"class\""))
         
         let inputGraphWithoutTypeKindInformation = """
-{
-  "accessLevel" : "public",
-  "kind" : {
-    "displayName" : "Instance Method",
-    "identifier" : "swift.method"
-  },
-  "pathComponents" : [
-    "ClassName",
-    "something()"
-  ],
-  "identifier" : {
-    "precise" : "precise-identifier",
-    "interfaceLanguage" : "swift"
-  },
-  "names" : {
-    "title" : "something()"
-  },
-  "swiftExtension": {
-    "extendedModule": "ExtendedModule",
-  },
-  "declarationFragments" : [
-    {
-      "kind" : "keyword",
-      "spelling" : "func"
-    },
-    {
-      "kind" : "text",
-      "spelling" : " "
-    },
-    {
-      "kind" : "identifier",
-      "spelling" : "something"
-    },
-    {
-      "kind" : "text",
-      "spelling" : "() -> "
-    },
-    {
-      "kind" : "keyword",
-      "spelling" : "Any"
-    }
-  ]
-}
-""".data(using: .utf8)!
+        {
+          "accessLevel" : "public",
+          "kind" : {
+            "displayName" : "Instance Method",
+            "identifier" : "swift.method"
+          },
+          "pathComponents" : [
+            "ClassName",
+            "something()"
+          ],
+          "identifier" : {
+            "precise" : "precise-identifier",
+            "interfaceLanguage" : "swift"
+          },
+          "names" : {
+            "title" : "something()"
+          },
+          "swiftExtension": {
+            "extendedModule": "ExtendedModule",
+          },
+          "declarationFragments" : [
+            {
+              "kind" : "keyword",
+              "spelling" : "func"
+            },
+            {
+              "kind" : "text",
+              "spelling" : " "
+            },
+            {
+              "kind" : "identifier",
+              "spelling" : "something"
+            },
+            {
+              "kind" : "text",
+              "spelling" : "() -> "
+            },
+            {
+              "kind" : "keyword",
+              "spelling" : "Any"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
     
         let symbolWithoutTypeKind = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: inputGraphWithoutTypeKindInformation)
         XCTAssertNotNil((symbolWithoutTypeKind.mixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] as? SymbolGraph.Symbol.Swift.Extension))
@@ -365,46 +365,46 @@ private func encodedSymbol(withDocComment: (lines: [String], rangeStart: (line: 
     }
     
     return """
-{
-  "accessLevel" : "public",
-  "kind" : {
-    "displayName" : "Instance Method",
-    "identifier" : "swift.method"
-  },
-  "pathComponents" : [
-    "ClassName",
-    "something()"
-  ],
-  "identifier" : {
-    "precise" : "precise-identifier",
-    "interfaceLanguage" : "swift"
-  },
-  "names" : {
-    "title" : "something()"
-  },
-  "docComment" : \(docCommentJSON),
-  "declarationFragments" : [
     {
-      "kind" : "keyword",
-      "spelling" : "func"
-    },
-    {
-      "kind" : "text",
-      "spelling" : " "
-    },
-    {
-      "kind" : "identifier",
-      "spelling" : "something"
-    },
-    {
-      "kind" : "text",
-      "spelling" : "() -> "
-    },
-    {
-      "kind" : "keyword",
-      "spelling" : "Any"
+      "accessLevel" : "public",
+      "kind" : {
+        "displayName" : "Instance Method",
+        "identifier" : "swift.method"
+      },
+      "pathComponents" : [
+        "ClassName",
+        "something()"
+      ],
+      "identifier" : {
+        "precise" : "precise-identifier",
+        "interfaceLanguage" : "swift"
+      },
+      "names" : {
+        "title" : "something()"
+      },
+      "docComment" : \(docCommentJSON),
+      "declarationFragments" : [
+        {
+          "kind" : "keyword",
+          "spelling" : "func"
+        },
+        {
+          "kind" : "text",
+          "spelling" : " "
+        },
+        {
+          "kind" : "identifier",
+          "spelling" : "something"
+        },
+        {
+          "kind" : "text",
+          "spelling" : "() -> "
+        },
+        {
+          "kind" : "keyword",
+          "spelling" : "Any"
+        }
+      ]
     }
-  ]
-}
-"""
+    """
 }

--- a/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/SymbolTests.swift
@@ -238,107 +238,26 @@ class SymbolTests: XCTestCase {
     func testOptionalExtensionTypeKindCoding() throws {
         let inputGraphWithTypeKindInformation = """
         {
-          "accessLevel" : "public",
-          "kind" : {
-            "displayName" : "Instance Method",
-            "identifier" : "swift.method"
-          },
-          "pathComponents" : [
-            "ClassName",
-            "something()"
-          ],
-          "identifier" : {
-            "precise" : "precise-identifier",
-            "interfaceLanguage" : "swift"
-          },
-          "names" : {
-            "title" : "something()"
-          },
-          "swiftExtension": {
-            "extendedModule": "ExtendedModule",
-            "typeKind": "class"
-          },
-          "declarationFragments" : [
-            {
-              "kind" : "keyword",
-              "spelling" : "func"
-            },
-            {
-              "kind" : "text",
-              "spelling" : " "
-            },
-            {
-              "kind" : "identifier",
-              "spelling" : "something"
-            },
-            {
-              "kind" : "text",
-              "spelling" : "() -> "
-            },
-            {
-              "kind" : "keyword",
-              "spelling" : "Any"
-            }
-          ]
+          "extendedModule": "ExtendedModule",
+          "typeKind": "class"
         }
         """.data(using: .utf8)!
     
-        let symbolWithTypeKind = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: inputGraphWithTypeKindInformation)
-        XCTAssertNotNil((symbolWithTypeKind.mixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] as? SymbolGraph.Symbol.Swift.Extension)?.typeKind)
+        let mixinWithTypeKind = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.Extension.self, from: inputGraphWithTypeKindInformation)
+        XCTAssert(mixinWithTypeKind.typeKind?.identifier == "class")
         
-        XCTAssertTrue(String(data: try JSONEncoder().encode(symbolWithTypeKind), encoding: .utf8)!.contains("\"typeKind\":\"class\""))
+        let roundTripCodedMixinWithTypeKind = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.Extension.self, from: try JSONEncoder().encode(mixinWithTypeKind))
+        
+        XCTAssert(roundTripCodedMixinWithTypeKind.typeKind?.identifier == "class")
         
         let inputGraphWithoutTypeKindInformation = """
         {
-          "accessLevel" : "public",
-          "kind" : {
-            "displayName" : "Instance Method",
-            "identifier" : "swift.method"
-          },
-          "pathComponents" : [
-            "ClassName",
-            "something()"
-          ],
-          "identifier" : {
-            "precise" : "precise-identifier",
-            "interfaceLanguage" : "swift"
-          },
-          "names" : {
-            "title" : "something()"
-          },
-          "swiftExtension": {
-            "extendedModule": "ExtendedModule",
-          },
-          "declarationFragments" : [
-            {
-              "kind" : "keyword",
-              "spelling" : "func"
-            },
-            {
-              "kind" : "text",
-              "spelling" : " "
-            },
-            {
-              "kind" : "identifier",
-              "spelling" : "something"
-            },
-            {
-              "kind" : "text",
-              "spelling" : "() -> "
-            },
-            {
-              "kind" : "keyword",
-              "spelling" : "Any"
-            }
-          ]
+          "extendedModule": "ExtendedModule",
         }
         """.data(using: .utf8)!
     
-        let symbolWithoutTypeKind = try JSONDecoder().decode(SymbolGraph.Symbol.self, from: inputGraphWithoutTypeKindInformation)
-        XCTAssertNotNil((symbolWithoutTypeKind.mixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] as? SymbolGraph.Symbol.Swift.Extension))
-        XCTAssertNil((symbolWithoutTypeKind.mixins[SymbolGraph.Symbol.Swift.Extension.mixinKey] as? SymbolGraph.Symbol.Swift.Extension)!.typeKind)
-        
-        XCTAssertFalse(String(data: try JSONEncoder().encode(symbolWithoutTypeKind), encoding: .utf8)!.contains("\"typeKind\":\"class\""))
+        let mixinWithoutTypeKind = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.Extension.self, from: inputGraphWithoutTypeKindInformation)
+        XCTAssertNil(mixinWithoutTypeKind.typeKind)
     }
 }
 


### PR DESCRIPTION
Related to: apple/swift#59047, apple/swift-docc#210

## Summary

This PR introduces the new `swift.extension` Symbol Kind and the  `extensionTo` Relationship Kind. In addition, it adds an optional `typeKind` field to the `Swift.Extension` Mixin.

These adaptions are necessary so that the `-emit-extension-block-symbols` format introduced in apple/swift#59047 can be parsed properly.

> **Warning** Since this PR adds the `extension` case to `SymbolGraph.Symbol.KindIdentifier`, this RP can break existing code.

## Dependencies

apple/swift#59047

## Testing

There is a new unit test for decoding `Swift.Extension`'s optional `typeKind` property.

The following files were produced with the `-emit-extension-block-symbols` mode from apple/swift#59047. Those and the old format should be decoded and re-encoded without errors or warnings.

[Symbol Graph Files.zip](https://github.com/apple/swift-docc-symbolkit/files/9063449/Symbol.Graph.Files.zip)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary