### PR TITLE
don't update a symbol graph's module name if it's an extension

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -42,19 +42,17 @@ extension GraphCollector {
     ///   - url: The file name where the given symbol graph is located. Used to determine whether a symbol graph
     ///     contains primary symbols or extensions.
     public func mergeSymbolGraph(_ inputGraph: SymbolGraph, at url: URL, forceLoading: Bool = false) {
-        var graph = inputGraph
-        let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(graph, at: url)
+        let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(inputGraph, at: url)
 
         if !isMainSymbolGraph && !forceLoading {
-            graph.module.name = moduleName
-            self.extensionGraphs[url] = graph
+            self.extensionGraphs[url] = inputGraph
             return
         }
 
         if let existingGraph = self.unifiedGraphs[moduleName] {
-            existingGraph.mergeGraph(graph: graph, at: url)
+            existingGraph.mergeGraph(graph: inputGraph, at: url)
         } else {
-            self.unifiedGraphs[moduleName] = UnifiedSymbolGraph(fromSingleGraph: graph, at: url)
+            self.unifiedGraphs[moduleName] = UnifiedSymbolGraph(fromSingleGraph: inputGraph, at: url)
         }
 
         let graphURL: GraphKind


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://94736726 (not tagged in the commit since it will require a corresponding Swift-DocC PR)

## Summary

Currently, we overwrite the `module.name` of a symbol graph in the `GraphCollector` when it looks like an extension symbol graph (i.e. a filename of `SomeModule@OtherModule.symbols.json`). However, this can cause a problem when the original module name is required to properly render symbols from the file (e.g. when it's a cross-import overlay and the module name is actually the name of the declaring module). Since Swift-DocC already handles the module name itself, this PR removes that behavior from SymbolKit so that that information can be made available to Swift-DocC.

Extension symbol graphs will still be unified with their extension module, as before, but the module data in the loaded graph will reflect the module in which it was declared.

## Dependencies

None

## Testing

Unified graph merging should work as before, but the `modules` map in symbols that came from extensions should reflect the module where the symbol came from. Further instructions will be available in the Swift-DocC PR.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary