### PR TITLE
[5.7] don't update a symbol graph's module name if it's an extension

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -42,19 +42,17 @@ extension GraphCollector {
     ///   - url: The file name where the given symbol graph is located. Used to determine whether a symbol graph
     ///     contains primary symbols or extensions.
     public func mergeSymbolGraph(_ inputGraph: SymbolGraph, at url: URL, forceLoading: Bool = false) {
-        var graph = inputGraph
-        let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(graph, at: url)
+        let (moduleName, isMainSymbolGraph) = Self.moduleNameFor(inputGraph, at: url)
 
         if !isMainSymbolGraph && !forceLoading {
-            graph.module.name = moduleName
-            self.extensionGraphs[url] = graph
+            self.extensionGraphs[url] = inputGraph
             return
         }
 
         if let existingGraph = self.unifiedGraphs[moduleName] {
-            existingGraph.mergeGraph(graph: graph, at: url)
+            existingGraph.mergeGraph(graph: inputGraph, at: url)
         } else {
-            self.unifiedGraphs[moduleName] = UnifiedSymbolGraph(fromSingleGraph: graph, at: url)
+            self.unifiedGraphs[moduleName] = UnifiedSymbolGraph(fromSingleGraph: inputGraph, at: url)
         }
 
         let graphURL: GraphKind


### PR DESCRIPTION
**Rationale**: Currently, SymbolKit will overwrite the module name of a symbol graph if it detects that it is an "extension" graph. However, this causes problems in Swift-DocC when the module is actually a cross-import overlay, so this PR stops this behavior so that Swift-DocC has the correct module information.
**Risk**: Low
**Risk Detail**: This is a behavior change for SymbolKit, but a minor one - extension symbol graphs are still unified with the symbols of their extended module.
**Reward**: Medium
**Reward Details**: Having this information available to Swift-DocC allows it to render symbols from cross-import overlay modules correctly.
**Original PR**: https://github.com/apple/swift-docc-symbolkit/pull/46
**Issue**: rdar://94736726 (note that this commit is not tagged with a radar number because the Swift-DocC change is also required)
**Code Reviewed By**: @franklinsch 
**Testing Details**: See https://github.com/apple/swift-docc/pull/332