### PR TITLE
MergeStrategy with ExtensionGraphAssociation Option for GraphCollector

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -27,37 +27,27 @@ public class GraphCollector {
 
     var extensionGraphs: [URL: SymbolGraph] = [:]
     
-    private let strategy: MergeStrategy
+    private let extensionGraphAssociationStrategy: ExtensionGraphAssociation
 
     /// Initialize a new collector for merging ``SymbolGraph``s into ``UnifiedSymbolGraph``s.
     ///
-    /// - Parameter strategy: Optionally specifiy how graphs are to be merged.
-    public init(strategy: MergeStrategy = MergeStrategy()) {
+    /// - Parameter extensionGraphAssociationStrategy: Optionally specifiy how extension graphs are to be merged.
+    public init(extensionGraphAssociationStrategy: ExtensionGraphAssociation = .extendedGraph) {
         self.unifiedGraphs = [:]
         self.graphSources = [:]
         self.extensionGraphs = [:]
-        self.strategy = strategy
+        self.extensionGraphAssociationStrategy = extensionGraphAssociationStrategy
     }
 }
 
 extension GraphCollector {
-    /// Describes the strategy for how to merge symbol graph files.
-    public struct MergeStrategy {
-        public init(extensionGraphAssociation: GraphCollector.MergeStrategy.ExtensionGraphAssociation = .extendedGraph) {
-            self.extensionGraphAssociation = extensionGraphAssociation
-        }
-        
-        /// Describes which graph an extension graph is merged with.
-        public var extensionGraphAssociation: ExtensionGraphAssociation
-        
-        /// Describes which graph an extension graph (named `ExtendingModule@ExtendedModule.symbols.json`)
-        /// is merged with.
-        public enum ExtensionGraphAssociation {
-            /// Merge with the extending module
-            case extendingGraph
-            /// Merge with the extended module
-            case extendedGraph
-        }
+    /// Describes which graph an extension graph (named `ExtendingModule@ExtendedModule.symbols.json`)
+    /// is merged with.
+    public enum ExtensionGraphAssociation {
+        /// Merge with the extending module
+        case extendingGraph
+        /// Merge with the extended module
+        case extendedGraph
     }
 }
 
@@ -71,7 +61,7 @@ extension GraphCollector {
     public func mergeSymbolGraph(_ inputGraph: SymbolGraph, at url: URL, forceLoading: Bool = false) {
         let (extendedModuleName, isMainSymbolGraph) = Self.moduleNameFor(inputGraph, at: url)
 
-        let moduleName = strategy.extensionGraphAssociation == .extendedGraph ? extendedModuleName : inputGraph.module.name
+        let moduleName = extensionGraphAssociationStrategy == .extendedGraph ? extendedModuleName : inputGraph.module.name
 
         if !isMainSymbolGraph && !forceLoading {
             self.extensionGraphs[url] = inputGraph

--- a/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
@@ -67,21 +67,16 @@ class GraphCollectorTests: XCTestCase {
         
         XCTAssertEqual(unifiedGraphs.count, 2)
         
-        for graph in unifiedGraphs.values {
-            if graph.moduleName == "A" {
-                XCTAssertEqual(graph.symbols.count, 1)
-                XCTAssertTrue(graph.symbols.keys.contains("s:AA"))
-            } else if graph.moduleName == "B" {
-                XCTAssertEqual(graph.symbols.count, 2)
-                XCTAssertTrue(graph.symbols.keys.contains("s:BB"))
-                XCTAssertTrue(graph.symbols.keys.contains("s:BBAatB"))
-            } else {
-                XCTFail()
-            }
-        }
+        var graphA = try XCTUnwrap(unifiedGraphs["A"])
+        XCTAssertEqual(graphA.symbols.count, 1)
+        XCTAssert(graphA.symbols.keys.contains("s:AA"))
+        var graphB = try XCTUnwrap(unifiedGraphs["B"])
+        XCTAssertEqual(graphB.symbols.count, 2)
+        XCTAssert(graphB.symbols.keys.contains("s:BB"))
+        XCTAssert(graphB.symbols.keys.contains("s:BBAatB"))
         
         // test with extendingGraph association strategy (extension graphs get attached to extend**ing** graph
-        collector = GraphCollector(strategy: .init(extensionGraphAssociation: .extendingGraph))
+        collector = GraphCollector(extensionGraphAssociationStrategy: .extendingGraph)
         
         collector.mergeSymbolGraph(a, at: .init(fileURLWithPath: "A.symbols.json"))
         collector.mergeSymbolGraph(b, at: .init(fileURLWithPath: "B.symbols.json"))
@@ -91,17 +86,12 @@ class GraphCollectorTests: XCTestCase {
         
         XCTAssertEqual(unifiedGraphs.count, 2)
         
-        for graph in unifiedGraphs.values {
-            if graph.moduleName == "A" {
-                XCTAssertEqual(graph.symbols.count, 2)
-                XCTAssertTrue(graph.symbols.keys.contains("s:AA"))
-                XCTAssertTrue(graph.symbols.keys.contains("s:BBAatB"))
-            } else if graph.moduleName == "B" {
-                XCTAssertEqual(graph.symbols.count, 1)
-                XCTAssertTrue(graph.symbols.keys.contains("s:BB"))
-            } else {
-                XCTFail()
-            }
-        }
+        graphA = try XCTUnwrap(unifiedGraphs["A"])
+        XCTAssertEqual(graphA.symbols.count, 2)
+        XCTAssert(graphA.symbols.keys.contains("s:AA"))
+        XCTAssert(graphA.symbols.keys.contains("s:BBAatB"))
+        graphB = try XCTUnwrap(unifiedGraphs["B"])
+        XCTAssertEqual(graphB.symbols.count, 1)
+        XCTAssert(graphB.symbols.keys.contains("s:BB"))
     }
 }

--- a/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
@@ -1,0 +1,107 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import Foundation
+@testable import SymbolKit
+
+class GraphCollectorTests: XCTestCase {
+    /// Verify that extension graphs are merged with the correct main graph depending on
+    /// the chosen strategy.
+    func testExtensionGraphMergingStrategies() throws {
+        let a = SymbolGraph(metadata: .init(formatVersion: .init(major: 1, minor: 0, patch: 0), generator: "unit-test"),
+                            module: .init(name: "A", platform: .init()),
+                            symbols: [
+                                .init(identifier: .init(precise: "s:AA", interfaceLanguage: "swift"),
+                                      names: .init(title: "A", navigator: nil, subHeading: nil, prose: nil),
+                                      pathComponents: ["A"],
+                                      docComment: nil,
+                                      accessLevel: .init(rawValue: "public"),
+                                      kind: .init(parsedIdentifier: .class, displayName: "Class"),
+                                      mixins: [:])
+                            ],
+                            relationships: [])
+        
+        let b = SymbolGraph(metadata: .init(formatVersion: .init(major: 1, minor: 0, patch: 0), generator: "unit-test"),
+                            module: .init(name: "B", platform: .init()),
+                            symbols: [
+                                .init(identifier: .init(precise: "s:BB", interfaceLanguage: "swift"),
+                                      names: .init(title: "B", navigator: nil, subHeading: nil, prose: nil),
+                                      pathComponents: ["B"],
+                                      docComment: nil,
+                                      accessLevel: .init(rawValue: "public"),
+                                      kind: .init(parsedIdentifier: .class, displayName: "Class"),
+                                      mixins: [:])
+                            ],
+                            relationships: [])
+        
+        let a_At_B = SymbolGraph(metadata: .init(formatVersion: .init(major: 1, minor: 0, patch: 0), generator: "unit-test"),
+                            module: .init(name: "A", platform: .init()),
+                            symbols: [
+                                .init(identifier: .init(precise: "s:BBAatB", interfaceLanguage: "swift"),
+                                      names: .init(title: "AatB", navigator: nil, subHeading: nil, prose: nil),
+                                      pathComponents: ["B", "AatB"],
+                                      docComment: nil,
+                                      accessLevel: .init(rawValue: "public"),
+                                      kind: .init(parsedIdentifier: .class, displayName: "Class"),
+                                      mixins: [:])
+                            ],
+                            relationships: [])
+        
+        
+        // test with default strategy (extension graphs get attached to extend**ed** graph
+        var collector = GraphCollector()
+
+        collector.mergeSymbolGraph(a, at: .init(fileURLWithPath: "A.symbols.json"))
+        collector.mergeSymbolGraph(b, at: .init(fileURLWithPath: "B.symbols.json"))
+        collector.mergeSymbolGraph(a_At_B, at: .init(fileURLWithPath: "A@B.symbols.json"))
+        
+        var (unifiedGraphs, _) = collector.finishLoading()
+        
+        XCTAssertEqual(unifiedGraphs.count, 2)
+        
+        for graph in unifiedGraphs.values {
+            if graph.moduleName == "A" {
+                XCTAssertEqual(graph.symbols.count, 1)
+                XCTAssertTrue(graph.symbols.keys.contains("s:AA"))
+            } else if graph.moduleName == "B" {
+                XCTAssertEqual(graph.symbols.count, 2)
+                XCTAssertTrue(graph.symbols.keys.contains("s:BB"))
+                XCTAssertTrue(graph.symbols.keys.contains("s:BBAatB"))
+            } else {
+                XCTFail()
+            }
+        }
+        
+        // test with extendingGraph association strategy (extension graphs get attached to extend**ing** graph
+        collector = GraphCollector(strategy: .init(extensionGraphAssociation: .extendingGraph))
+        
+        collector.mergeSymbolGraph(a, at: .init(fileURLWithPath: "A.symbols.json"))
+        collector.mergeSymbolGraph(b, at: .init(fileURLWithPath: "B.symbols.json"))
+        collector.mergeSymbolGraph(a_At_B, at: .init(fileURLWithPath: "A@B.symbols.json"))
+        
+        (unifiedGraphs, _) = collector.finishLoading()
+        
+        XCTAssertEqual(unifiedGraphs.count, 2)
+        
+        for graph in unifiedGraphs.values {
+            if graph.moduleName == "A" {
+                XCTAssertEqual(graph.symbols.count, 2)
+                XCTAssertTrue(graph.symbols.keys.contains("s:AA"))
+                XCTAssertTrue(graph.symbols.keys.contains("s:BBAatB"))
+            } else if graph.moduleName == "B" {
+                XCTAssertEqual(graph.symbols.count, 1)
+                XCTAssertTrue(graph.symbols.keys.contains("s:BB"))
+            } else {
+                XCTFail()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adaption is required to fix apple/swift-docc#210

## Summary

Adds a strategy option to `GraphCollector`'s init. The `ExtensionGraphAssociation` option decides if extension graphs are merged with the extend**ing** or extend**ed** graph.

## Dependencies

This PR does not introduce a breaking change and can be merged independently.

## Testing

I added a new unit test to test the merging behavior for both ExtensionGraphAssociation options.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary