### PR TITLE
encode relationshipsByLanguage and orphanRelationships in dump-unified-graph

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph+Encodable.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph+Encodable.swift
@@ -16,7 +16,8 @@ extension UnifiedSymbolGraph: Encodable {
         case moduleData
         case metadata
         case symbols
-        case relationships
+        case relationshipsByLanguage
+        case orphanRelationships
     }
 
     private struct EncodableModuleData: Encodable {
@@ -27,6 +28,11 @@ extension UnifiedSymbolGraph: Encodable {
     private struct EncodableMetadata: Encodable {
         var url: URL
         var metadata: SymbolGraph.Metadata
+    }
+
+    private struct EncodableRelationships: Encodable {
+        var selector: Selector
+        var relationships: [SymbolGraph.Relationship]
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -41,6 +47,10 @@ extension UnifiedSymbolGraph: Encodable {
         try container.encode(encodableMetadata, forKey: .metadata)
 
         try container.encode(Array(symbols.values), forKey: .symbols)
-        try container.encode(relationships, forKey: .relationships)
+
+        let encodableRelationships = relationshipsByLanguage.map({ EncodableRelationships(selector: $0.key, relationships: $0.value) })
+        try container.encode(encodableRelationships, forKey: .relationshipsByLanguage)
+
+        try container.encode(orphanRelationships, forKey: .orphanRelationships)
     }
 }

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
@@ -28,7 +28,7 @@ public class UnifiedSymbolGraph {
     public var symbols: [String: UnifiedSymbolGraph.Symbol]
 
     /// The relationships between symbols.
-    @available(*, deprecated, message: "Use unifiedRelationships and orphanRelationships instead")
+    @available(*, deprecated, message: "Use relationshipsByLanguage and orphanRelationships instead")
     public var relationships: [SymbolGraph.Relationship] {
         var allRelations = mergeRelationships(Array(relationshipsByLanguage.values.joined()))
         allRelations.append(contentsOf: self.orphanRelationships)


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

When https://github.com/apple/swift-docc-symbolkit/pull/28 landed, the code for dump-unified-graph was not updated to use the new relationship data. This PR updates the Encodable extension on UnifiedSymbolGraph to use the `relationshipsByLanguage` and `orphanRelationships` properties instead of the old unified `relationships` property. This removes a deprecation warning when building SymbolKit.

## Dependencies

None

## Testing

Rerun the testing instructions for https://github.com/apple/swift-docc-symbolkit/pull/29. The Xcode 14 beta will generate multiple symbol graphs per-language, so passing the symbol-graph directory from a project's build folder to `--symbol-graph-dir` will work.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary