### PR TITLE
Add Missing Memberwise Initializers to Mixins

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/FunctionSignature/FunctionSignature.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/FunctionSignature/FunctionSignature.swift
@@ -30,6 +30,11 @@ extension SymbolGraph.Symbol {
          */
         public var returns: [DeclarationFragments.Fragment]
 
+        public init(parameters: [SymbolGraph.Symbol.FunctionSignature.FunctionParameter], returns: [SymbolGraph.Symbol.DeclarationFragments.Fragment]) {
+            self.parameters = parameters
+            self.returns = returns
+        }
+        
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             parameters = try container.decodeIfPresent([FunctionParameter].self, forKey: .parameters) ?? []

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Swift/Extension.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Swift/Extension.swift
@@ -33,6 +33,11 @@ extension SymbolGraph.Symbol.Swift {
             case extendedModule
             case constraints
         }
+        
+        public init(extendedModule: String, constraints: [SymbolGraph.Symbol.Swift.GenericConstraint]) {
+            self.extendedModule = extendedModule
+            self.constraints = constraints
+        }
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Swift/Generics.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Swift/Generics.swift
@@ -47,6 +47,11 @@ extension SymbolGraph.Symbol.Swift {
          There is a *conformance constraint* involving `S`.
          */
         public var constraints: [GenericConstraint]
+        
+        public init(parameters: [SymbolGraph.Symbol.Swift.GenericParameter], constraints: [SymbolGraph.Symbol.Swift.GenericConstraint]) {
+            self.parameters = parameters
+            self.constraints = constraints
+        }
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)


### PR DESCRIPTION
## Summary

Some `Mixin`s were missing memberwise initializers. These are required for writing test-cases in apple/swift-docc#335.

## Dependencies

None.

## Testing

No testing required as change is trivial.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary