### PR TITLE
Add models for JSON dictionaries

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/AnyScalar.swift
+++ b/Sources/SymbolKit/SymbolGraph/AnyScalar.swift
@@ -1,0 +1,145 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension SymbolGraph {
+    /// Enumeration that can hold either a single boolean, integer, floating point, or string value or a null value.
+    /// 
+    /// This enumeration is used when a field within the symbol graph can hold a different value type
+    /// depending on the context. One such case would be the default value of a dictionary property, whose
+    /// value depends on the data type of the property (eg, a string or integer).
+    public enum AnyScalar: Codable, Equatable {
+        case null
+        case boolean(Bool)
+        case integer(Int)
+        case float(Double)
+        case string(String)
+        
+        // This empty-marker case is here because non-frozen enums are only available when Library
+        // Evolution is enabled, which is not available to Swift Packages without unsafe flags
+        // (rdar://78773361). This can be removed once that is available and applied to SymbolKit
+        // (rdar://89033233).
+        @available(*, deprecated, message: "this enum is nonfrozen and may be expanded in the future; please add a `default` case instead of matching this one")
+        case _nonfrozenEnum_useDefaultCase
+        
+        public func encode(to encoder : Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .null:
+                try container.encodeNil()
+            case .boolean(let b):
+                try container.encode(b)
+            case .integer(let i):
+                try container.encode(i)
+            case .float(let d):
+                try container.encode(d)
+            case .string(let s):
+                try container.encode(s)
+            case ._nonfrozenEnum_useDefaultCase:
+                fatalError("_nonfrozenEnum_useDefaultCase is not a supported case in AnyScalar")
+            }
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let singleValue = try decoder.singleValueContainer()
+            if singleValue.decodeNil() {
+                self = .null
+            } else if let value = try? singleValue.decode(Swift.Bool.self) {
+                self = .boolean(value)
+            } else if let value = try? singleValue.decode(Swift.Int.self) {
+                self = .integer(value)
+            } else if let value = try? singleValue.decode(Swift.Double.self) {
+                self = .float(value)
+            } else if let value = try? singleValue.decode(Swift.String.self) {
+                self = .string(value)
+            } else {
+                throw DecodingError.typeMismatch(
+                    AnyScalar.self,
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Unable to parse scalar value"
+                    )
+                )
+            }
+        }
+    }
+    
+    /// Enumeration that can hold either an integer or floating point value.
+    /// 
+    /// This enumeration is used when a field within the symbol graph can hold a different value type
+    /// depending on the context. One such case would be the minimum value of a dictionary property, whose
+    /// value depends on the numerical type of the property (eg, an integer or floating point).
+    public enum AnyNumber: Codable, Equatable {
+        case integer(Int)
+        case float(Double)
+        
+        // This empty-marker case is here because non-frozen enums are only available when Library
+        // Evolution is enabled, which is not available to Swift Packages without unsafe flags
+        // (rdar://78773361). This can be removed once that is available and applied to SymbolKit
+        // (rdar://89033233).
+        @available(*, deprecated, message: "this enum is nonfrozen and may be expanded in the future; please add a `default` case instead of matching this one")
+        case _nonfrozenEnum_useDefaultCase
+        
+        public func encode(to encoder : Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .integer(let i):
+                try container.encode(i)
+            case .float(let d):
+                try container.encode(d)
+            case ._nonfrozenEnum_useDefaultCase:
+                fatalError("_nonfrozenEnum_useDefaultCase is not a supported case in AnyNumber")
+            }
+            
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let value = try? container.decode(Swift.Int.self) {
+                self = .integer(value)
+            } else if let value = try? container.decode(Swift.Double.self) {
+                self = .float(value)
+            } else {
+                throw DecodingError.typeMismatch(AnyScalar.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unable to parse number value"))
+            }
+        }
+    }
+}
+
+extension String {
+    public init(_ value: SymbolGraph.AnyScalar) {
+        switch value {
+        case .null:
+            self = "null"
+        case .boolean(let b):
+            self = String(b)
+        case .integer(let i):
+            self = String(i)
+        case .float(let d):
+            self = String(d)
+        case .string(let s):
+            self = s
+        case ._nonfrozenEnum_useDefaultCase:
+            fatalError("_nonfrozenEnum_useDefaultCase is not a supported case in AnyScalar")
+        }
+    }
+    
+    public init(_ value: SymbolGraph.AnyNumber) {
+        switch value {
+        case .integer(let i):
+            self = String(i)
+        case .float(let d):
+            self = String(d)
+        case ._nonfrozenEnum_useDefaultCase:
+            fatalError("_nonfrozenEnum_useDefaultCase is not a supported case in AnyNumber")
+        }
+    }
+}

--- a/Sources/SymbolKit/SymbolGraph/Relationship/RelationshipKind.swift
+++ b/Sources/SymbolKit/SymbolGraph/Relationship/RelationshipKind.swift
@@ -31,6 +31,18 @@ extension SymbolGraph.Relationship {
         public static let memberOf = Kind(rawValue: "memberOf")
 
         /**
+         A symbol `A` is an optional member of another symbol `B`.
+
+         For example, a key for a dictionary could be
+         a member of that dictionary, but the key is not guaranteed
+         to be present.
+
+         The implied inverse of this relationship is that
+         symbol `B` is the owner of a member symbol `A`.
+         */
+        public static let optionalMemberOf = Kind(rawValue: "optionalMemberOf")
+
+        /**
          A symbol `A` conforms to an interface/protocol symbol `B`.
 
          For example, a class `C` that conforms to protocol `P` in Swift would

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Availability.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Availability.swift
@@ -53,4 +53,9 @@ extension SymbolGraph.Symbol {
             self.availability = availability
         }
     }
+    
+    /// Convenience method to fetch the availability mixin value.
+    public var availability: [Availability.AvailabilityItem]? {
+        (mixins[Availability.mixinKey] as? Availability)?.availability
+    }
 }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/DeclarationFragments/DeclarationFragments.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/DeclarationFragments/DeclarationFragments.swift
@@ -154,4 +154,10 @@ extension SymbolGraph.Symbol {
             try container.encode(declarationFragments)
         }
     }
+    
+    //// Convenience method to fetch the declaration fragment mixin value.
+    public var declarationFragments : [DeclarationFragments.Fragment]? {
+        (mixins[DeclarationFragments.mixinKey] as? DeclarationFragments)?
+            .declarationFragments
+    }
 }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -72,6 +72,10 @@ extension SymbolGraph.Symbol {
         public static let module = KindIdentifier(rawValue: "module")
         
         public static let `extension` = KindIdentifier(rawValue: "extension")
+        
+        public static let dictionary = KindIdentifier(rawValue: "dictionary")
+
+        public static let dictionaryKey = KindIdentifier(rawValue: "dictionaryKey")
 
         /// A string that uniquely identifies the symbol kind.
         ///
@@ -109,6 +113,8 @@ extension SymbolGraph.Symbol {
             Self.var.rawValue: .var,
             Self.module.rawValue: .module,
             Self.extension.rawValue: .extension,
+            Self.dictionary.rawValue: .dictionary,
+            Self.dictionaryKey.rawValue: .dictionaryKey,
         ]
         
         /// Register custom ``SymbolGraph/Symbol/KindIdentifier``s so they can be parsed correctly and

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Mutability.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Mutability.swift
@@ -40,4 +40,9 @@ extension SymbolGraph.Symbol {
             try container.encode(isReadOnly)
         }
     }
+    
+    /// Convenience method to fetch the mutability mixin value.
+    public var isReadOnly : Bool? {
+        (mixins[Mutability.mixinKey] as? Mutability)?.isReadOnly
+    }
 }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -224,6 +224,14 @@ extension SymbolGraph.Symbol {
         static let functionSignature = FunctionSignature.symbolCodingInfo
         static let spi = SPI.symbolCodingInfo
         static let snippet = Snippet.symbolCodingInfo
+        static let minimum = Minimum.symbolCodingInfo
+        static let maximum = Maximum.symbolCodingInfo
+        static let minimumExclusive = MinimumExclusive.symbolCodingInfo
+        static let maximumExclusive = MaximumExclusive.symbolCodingInfo
+        static let minimumLength = MinimumLength.symbolCodingInfo
+        static let maximumLength = MaximumLength.symbolCodingInfo
+        static let allowedValues = AllowedValues.symbolCodingInfo
+        static let defaultValue = DefaultValue.symbolCodingInfo
         
         static let mixinCodingInfo: [String: SymbolMixinCodingInfo] = [
             CodingKeys.availability.codingKey.stringValue: Self.availability,
@@ -236,6 +244,14 @@ extension SymbolGraph.Symbol {
             CodingKeys.functionSignature.codingKey.stringValue: Self.functionSignature,
             CodingKeys.spi.codingKey.stringValue: Self.spi,
             CodingKeys.snippet.codingKey.stringValue: Self.snippet,
+            CodingKeys.minimum.codingKey.stringValue: Self.minimum,
+            CodingKeys.maximum.codingKey.stringValue: Self.maximum,
+            CodingKeys.minimumExclusive.codingKey.stringValue: Self.minimumExclusive,
+            CodingKeys.maximumExclusive.codingKey.stringValue: Self.maximumExclusive,
+            CodingKeys.minimumLength.codingKey.stringValue: Self.minimumLength,
+            CodingKeys.maximumLength.codingKey.stringValue: Self.maximumLength,
+            CodingKeys.allowedValues.codingKey.stringValue: Self.allowedValues,
+            CodingKeys.defaultValue.codingKey.stringValue: Self.defaultValue,
         ]
         
         static func == (lhs: SymbolGraph.Symbol.CodingKeys, rhs: SymbolGraph.Symbol.CodingKeys) -> Bool {

--- a/Sources/SymbolKit/SymbolGraph/Symbol/ValueConstraints.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/ValueConstraints.swift
@@ -1,0 +1,132 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension SymbolGraph.Symbol {
+    // Set of constraints that describe the value held by a variable.
+    // 
+    // These constraints include the allowed minimum or maximum value,
+    // the minimum or maximum lengths of a string value,
+    // the exact allowed values, and the default value assumed when one isn't
+    // explicitly specified.
+    
+    /// The minimum value, which can be specified as an integer or floating point.
+    public struct Minimum: SingleValueMixin {
+        public static let mixinKey = "minimum"
+        public typealias ValueType = SymbolGraph.AnyNumber
+        public var value: ValueType
+        public init(_ value: ValueType) {
+            self.value = value
+        }
+    }
+    
+    public var minimum : SymbolGraph.AnyNumber? {
+        (mixins[Minimum.mixinKey] as? Minimum)?.value
+    }
+    
+    /// The maximum value, which can be specified as an integer or floating point.
+    public struct Maximum: SingleValueMixin {
+        public static let mixinKey = "maximum"
+        public typealias ValueType = SymbolGraph.AnyNumber
+        public var value: ValueType
+        public init(_ value: ValueType) {
+            self.value = value
+        }
+    }
+    
+    public var maximum : SymbolGraph.AnyNumber? {
+        (mixins[Maximum.mixinKey] as? Maximum)?.value
+    }
+    
+    /// The lower bound of allowed values, excluding the value itself, which can be specified as an integer or floating point.
+    public struct MinimumExclusive: SingleValueMixin {
+        public static let mixinKey = "minimumExclusive"
+        public typealias ValueType = SymbolGraph.AnyNumber
+        public var value: ValueType
+        public init(_ value: ValueType) {
+            self.value = value
+        }
+    }
+    
+    public var minimumExclusive : SymbolGraph.AnyNumber? {
+        (mixins[MinimumExclusive.mixinKey] as? MinimumExclusive)?.value
+    }
+    
+    /// The upper bound of allowed values, excluding the value itself, which can be specified as an integer or floating point.
+    public struct MaximumExclusive: SingleValueMixin {
+        public static let mixinKey = "maximumExclusive"
+        public typealias ValueType = SymbolGraph.AnyNumber
+        public var value: ValueType
+        public init(_ value: ValueType) {
+            self.value = value
+        }
+    }
+    
+    public var maximumExclusive : SymbolGraph.AnyNumber? {
+        (mixins[MaximumExclusive.mixinKey] as? MaximumExclusive)?.value
+    }
+    
+    /// The minimum length of a string.
+    public struct MinimumLength: SingleValueMixin {
+        public static let mixinKey = "minimumLength"
+        public typealias ValueType = Int
+        public var value: ValueType
+        public init(_ value: ValueType) {
+            self.value = value
+        }
+    }
+    
+    public var minimumLength : Int? {
+        (mixins[MinimumLength.mixinKey] as? MinimumLength)?.value
+    }
+    
+    /// The maximum length of a string.
+    public struct MaximumLength: SingleValueMixin {
+        public static let mixinKey = "maximumLength"
+        public typealias ValueType = Int
+        public var value: ValueType
+        public init(_ value: ValueType) {
+            self.value = value
+        }
+    }
+    
+    public var maximumLength : Int? {
+        (mixins[MaximumLength.mixinKey] as? MaximumLength)?.value
+    }
+    
+    /// The finite set of values allowed, which can be specified as strings, numbers, booleans, or a null, depending on context.
+    public struct AllowedValues: SingleValueMixin {
+        public static let mixinKey = "allowedValues"
+        public typealias ValueType = [SymbolGraph.AnyScalar]
+        public var value: ValueType
+        public init(_ value: ValueType) {
+            self.value = value
+        }
+    }
+    
+    public var allowedValues : [SymbolGraph.AnyScalar]? {
+        (mixins[AllowedValues.mixinKey] as? AllowedValues)?.value
+    }
+    
+    /// The default value, which can be specified as a string, number, boolean, or a null, depending on context.
+    public struct DefaultValue: SingleValueMixin {
+        public static let mixinKey = "default"
+        public typealias ValueType = SymbolGraph.AnyScalar
+        public var value: ValueType
+        public init(_ value: ValueType) {
+            self.value = value
+        }
+    }
+    
+    public var defaultValue : SymbolGraph.AnyScalar? {
+        (mixins[DefaultValue.mixinKey] as? DefaultValue)?.value
+    }
+}

--- a/Tests/SymbolKitTests/SymbolGraph/AnyScalarTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/AnyScalarTests.swift
@@ -1,0 +1,57 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import SymbolKit
+
+class AnyScalarTests: XCTestCase {
+    func testAnyScalarCanBeDecoded() throws {
+        let decoder = JSONDecoder()
+        var scalar = try decoder.decode(SymbolGraph.AnyScalar.self, from: "3".data(using: .utf8)!)
+        XCTAssertEqual(scalar, .integer(3))
+        
+        scalar = try decoder.decode(SymbolGraph.AnyScalar.self, from: "3.5".data(using: .utf8)!)
+        XCTAssertEqual(scalar, .float(3.5))
+        
+        scalar = try decoder.decode(SymbolGraph.AnyScalar.self, from: "\"test\"".data(using: .utf8)!)
+        XCTAssertEqual(scalar, .string("test"))
+        
+        scalar = try decoder.decode(SymbolGraph.AnyScalar.self, from: "true".data(using: .utf8)!)
+        XCTAssertEqual(scalar, .boolean(true))
+        
+        scalar = try decoder.decode(SymbolGraph.AnyScalar.self, from: "false".data(using: .utf8)!)
+        XCTAssertEqual(scalar, .boolean(false))
+        
+        scalar = try decoder.decode(SymbolGraph.AnyScalar.self, from: "null".data(using: .utf8)!)
+        XCTAssertEqual(scalar, .null)
+    }
+    
+    func testAnyScalarThrowsOnError() throws {
+        let decoder = JSONDecoder()
+        XCTAssertThrowsError(try decoder.decode(SymbolGraph.AnyScalar.self, from: "[3]".data(using: .utf8)!))
+        XCTAssertThrowsError(try decoder.decode(SymbolGraph.AnyScalar.self, from: "{}".data(using: .utf8)!))
+    }
+    
+    func testAnyNumberCanBeDecoded() throws {
+        let decoder = JSONDecoder()
+        var number = try decoder.decode(SymbolGraph.AnyNumber.self, from: "3".data(using: .utf8)!)
+        XCTAssertEqual(number, .integer(3))
+        
+        number = try decoder.decode(SymbolGraph.AnyNumber.self, from: "3.5".data(using: .utf8)!)
+        XCTAssertEqual(number, .float(3.5))
+    }
+    
+    func testAnyNumberThrowsOnError() throws {
+        let decoder = JSONDecoder()
+        XCTAssertThrowsError(try decoder.decode(SymbolGraph.AnyNumber.self, from: "[3]".data(using: .utf8)!))
+        XCTAssertThrowsError(try decoder.decode(SymbolGraph.AnyNumber.self, from: "{}".data(using: .utf8)!))
+        XCTAssertThrowsError(try decoder.decode(SymbolGraph.AnyNumber.self, from: "\"bad\"".data(using: .utf8)!))
+    }
+}

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/ValueConstraintsTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/ValueConstraintsTests.swift
@@ -1,0 +1,52 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import SymbolKit
+
+class ValueConstraintsTests: XCTestCase {
+    func testValueConstraintsCanBeDecoded() throws {
+        let jsonData = """
+          {
+            "accessLevel" : "public",
+            "identifier" : {
+              "interfaceLanguage" : "data",
+              "precise" : "data:example:Dictionary@property1"
+            },
+            "kind" : {
+              "displayName" : "Dictionary Key",
+              "identifier" : "dictionaryKey"
+            },
+            "names" : {
+              "title" : "property1"
+            },
+            "pathComponents": [],
+            "minimum": 3,
+            "maximum": 3.5,
+            "default": "str",
+            "allowedValues": ["a", 1, null],
+        }
+        """.data(using: .utf8)
+        
+        let decoder = JSONDecoder()
+        let symbol = try decoder.decode(SymbolGraph.Symbol.self, from: jsonData!)
+        
+        XCTAssertEqual(symbol.minimum, .integer(3))
+        XCTAssertEqual(symbol.maximum, .float(3.5))
+        XCTAssertEqual(symbol.defaultValue, .string("str"))
+        
+        let allowedValues = try XCTUnwrap(symbol.allowedValues)
+        XCTAssertEqual(allowedValues.count, 3)
+        XCTAssertEqual(allowedValues[0], .string("a"))
+        XCTAssertEqual(allowedValues[1], .integer(1))
+        XCTAssertEqual(allowedValues[2], .null)
+    }
+}
+

--- a/bin/check-source
+++ b/bin/check-source
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][89012]/YEARS/' -e 's/20[12][89012]/YEARS/'
+    sed -e 's/20[12][78901]-20[12][890123]/YEARS/' -e 's/20[12][890123]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language… "


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://101407961

## Summary

I've been experimenting with REST API documentation support, and this PR adds models in support of describing JSON object structures for request/responses.

## Dependencies

None.

## Testing

N/A, this is not a user-facing change.

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary