### PR TITLE
Add models for HTTP endpoints

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/HTTP/HTTP.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/HTTP/HTTP.swift
@@ -1,0 +1,124 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension SymbolGraph.Symbol {
+    /// The HTTP endpoint for a request.
+    public var httpEndpoint: HTTP.Endpoint? {
+        (mixins[HTTP.Endpoint.mixinKey] as? HTTP.Endpoint)
+    }
+    
+    /// The source location of an HTTP parameter.
+    public var httpParameterSource: String? {
+        (mixins[HTTP.ParameterSource.mixinKey] as? HTTP.ParameterSource)?.value
+    }
+    
+    /// The encoding media type for an HTTP payload.
+    public var httpMediaType: String? {
+        (mixins[HTTP.MediaType.mixinKey] as? HTTP.MediaType)?.value
+    }
+    
+    /// Namespace to hold mixins specific to HTTP requests
+    public enum HTTP {
+        
+        /// The HTTP endpoint for a request.
+        /// 
+        /// Defines the HTTP method, base URL, and path relative to the base URL.
+        public struct Endpoint: Mixin {
+            public static let mixinKey = "httpEndpoint"
+            
+            private var _method: String
+            
+            /// The HTTP method of the request.
+            /// 
+            /// Expected values include GET, PUT, POST, DELETE.
+            /// The value is always uppercased.
+            public var method: String {
+                get {
+                    return self._method
+                }
+                set {
+                    self._method = newValue.uppercased()
+                }
+            }
+            
+            /// The base URL of the request.
+            /// 
+            /// This portion of the URL is usually shared across all endpoints provided by a server.
+            /// It can be optionally swapped out of the request by the ``sandboxURL`` when accessing
+            /// the endpoint within a test environment.
+            public var baseURL: URL
+            
+            /// The alternate base URL of the request when used within a test environment.
+            public var sandboxURL: URL?
+            
+            /// The relative path specific to the endpoint.
+            /// 
+            /// The string can encode the location of parameters in the path using `{parameterName}` syntax.
+            /// The embedded parameter name must match an `httpParameter` symbol related to this endpoint's `httpRequest` symbol.
+            public var path: String
+            
+            public init(method: String, baseURL: URL, sandboxURL: URL? = nil, path: String) {
+                self._method = method.uppercased()
+                self.baseURL = baseURL
+                self.sandboxURL = sandboxURL
+                self.path = path
+            }
+            
+            enum CodingKeys: CodingKey {
+                case method
+                case baseURL
+                case sandboxURL
+                case path
+            }
+            
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                _method = try container.decode(String.self, forKey: .method).uppercased()
+                baseURL = try container.decode(URL.self, forKey: .baseURL)
+                sandboxURL = try container.decodeIfPresent(URL.self, forKey: .sandboxURL)
+                path = try container.decode(String.self, forKey: .path)
+            }
+            
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(method, forKey: .method)
+                try container.encode(baseURL, forKey: .baseURL)
+                try container.encodeIfPresent(sandboxURL, forKey: .sandboxURL)
+                try container.encode(path, forKey: .path)
+            }
+        }
+        
+        /// The source location of an HTTP parameter.
+        /// 
+        /// Expected values are path, query, header, or cookie.
+        public struct ParameterSource: SingleValueMixin {
+            public static let mixinKey = "httpParameterSource"
+            public typealias ValueType = String
+            public var value: ValueType
+            public init(_ value: ValueType) {
+                self.value = value
+            }
+        }
+        
+        /// The encoding media type for an HTTP payload.
+        /// 
+        /// Common values are "application/json" and "application/x-www-form-urlencoded".
+        public struct MediaType: SingleValueMixin {
+            public static let mixinKey = "httpMediaType"
+            public typealias ValueType = String
+            public var value: ValueType
+            public init(_ value: ValueType) {
+                self.value = value
+            }
+        }
+    }
+}

--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -77,6 +77,14 @@ extension SymbolGraph.Symbol {
 
         public static let dictionaryKey = KindIdentifier(rawValue: "dictionaryKey")
 
+        public static let httpRequest = KindIdentifier(rawValue: "httpRequest")
+
+        public static let httpParameter = KindIdentifier(rawValue: "httpParameter")
+
+        public static let httpResponse = KindIdentifier(rawValue: "httpResponse")
+
+        public static let httpBody = KindIdentifier(rawValue: "httpBody")
+
         /// A string that uniquely identifies the symbol kind.
         ///
         /// If the original kind string was not recognized, this will return `"unknown"`.
@@ -115,6 +123,10 @@ extension SymbolGraph.Symbol {
             Self.extension.rawValue: .extension,
             Self.dictionary.rawValue: .dictionary,
             Self.dictionaryKey.rawValue: .dictionaryKey,
+            Self.httpRequest.rawValue: .httpRequest,
+            Self.httpParameter.rawValue: .httpParameter,
+            Self.httpResponse.rawValue: .httpResponse,
+            Self.httpBody.rawValue: .httpBody,
         ]
         
         /// Register custom ``SymbolGraph/Symbol/KindIdentifier``s so they can be parsed correctly and

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -232,6 +232,9 @@ extension SymbolGraph.Symbol {
         static let maximumLength = MaximumLength.symbolCodingInfo
         static let allowedValues = AllowedValues.symbolCodingInfo
         static let defaultValue = DefaultValue.symbolCodingInfo
+        static let httpEndpoint = HTTP.Endpoint.symbolCodingInfo
+        static let httpParameterSource = HTTP.ParameterSource.symbolCodingInfo
+        static let httpMediaType = HTTP.MediaType.symbolCodingInfo
         
         static let mixinCodingInfo: [String: SymbolMixinCodingInfo] = [
             CodingKeys.availability.codingKey.stringValue: Self.availability,
@@ -252,6 +255,9 @@ extension SymbolGraph.Symbol {
             CodingKeys.maximumLength.codingKey.stringValue: Self.maximumLength,
             CodingKeys.allowedValues.codingKey.stringValue: Self.allowedValues,
             CodingKeys.defaultValue.codingKey.stringValue: Self.defaultValue,
+            CodingKeys.httpEndpoint.codingKey.stringValue: Self.httpEndpoint,
+            CodingKeys.httpParameterSource.codingKey.stringValue: Self.httpParameterSource,
+            CodingKeys.httpMediaType.codingKey.stringValue: Self.httpMediaType,
         ]
         
         static func == (lhs: SymbolGraph.Symbol.CodingKeys, rhs: SymbolGraph.Symbol.CodingKeys) -> Bool {

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/HTTPTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/HTTPTests.swift
@@ -1,0 +1,141 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import SymbolKit
+
+final class HTTPTests: XCTestCase {
+    func testRequestCanBeDecoded() throws {
+        let jsonData = """
+          {
+            "accessLevel" : "public",
+            "identifier" : {
+              "interfaceLanguage" : "data",
+              "precise" : "data:example:get:path1"
+            },
+            "kind" : {
+              "displayName" : "HTTP Request",
+              "identifier" : "httpRequest"
+            },
+            "names" : {
+              "title" : "Get Something"
+            },
+            "pathComponents": [],
+            "httpEndpoint": {
+                "method": "get",
+                "baseURL": "http://example.com",
+                "path": "path1"
+            }
+        }
+        """.data(using: .utf8)
+        
+        let decoder = JSONDecoder()
+        let symbol = try decoder.decode(SymbolGraph.Symbol.self, from: jsonData!)
+        
+        XCTAssertEqual(symbol.kind.identifier, .httpRequest)
+        XCTAssertNotNil(symbol.httpEndpoint)
+        if let endpoint = symbol.httpEndpoint {
+            XCTAssertEqual(endpoint.method, "GET")
+            XCTAssertEqual(endpoint.baseURL, URL(string: "http://example.com"))
+            XCTAssertEqual(endpoint.path, "path1")
+            XCTAssertNil(endpoint.sandboxURL)
+        }
+
+        // Verify that the endpoint's method is always forced to uppercase
+        var endpoint = SymbolGraph.Symbol.HTTP.Endpoint(method: "get", baseURL: URL(string: "http://example.com")!, path: "path")
+        XCTAssertEqual(endpoint.method, "GET")
+        endpoint.method = "put"
+        XCTAssertEqual(endpoint.method, "PUT")
+    }
+    
+    func testParameterCanBeDecoded() throws {
+        let jsonData = """
+          {
+            "accessLevel" : "public",
+            "identifier" : {
+              "interfaceLanguage" : "data",
+              "precise" : "data:example:get:path1@q=param1"
+            },
+            "kind" : {
+              "displayName" : "HTTP Parameter",
+              "identifier" : "httpParameter"
+            },
+            "names" : {
+              "title" : "param1"
+            },
+            "pathComponents": [],
+            "httpParameterSource": "query",
+        }
+        """.data(using: .utf8)
+        
+        let decoder = JSONDecoder()
+        let symbol = try decoder.decode(SymbolGraph.Symbol.self, from: jsonData!)
+        
+        XCTAssertEqual(symbol.kind.identifier, .httpParameter)
+        XCTAssertEqual(symbol.httpParameterSource, "query")
+        XCTAssertNil(symbol.httpEndpoint)
+    }
+    
+    func testResponseCanBeDecoded() throws {
+        let jsonData = """
+          {
+            "accessLevel" : "public",
+            "identifier" : {
+              "interfaceLanguage" : "data",
+              "precise" : "data:example:get:path1=200-application/json"
+            },
+            "kind" : {
+              "displayName" : "HTTP Response",
+              "identifier" : "httpResponse"
+            },
+            "names" : {
+              "title" : "200"
+            },
+            "pathComponents": [],
+            "httpMediaType": "application/json",
+        }
+        """.data(using: .utf8)
+        
+        let decoder = JSONDecoder()
+        let symbol = try decoder.decode(SymbolGraph.Symbol.self, from: jsonData!)
+        
+        XCTAssertEqual(symbol.kind.identifier, .httpResponse)
+        XCTAssertEqual(symbol.httpMediaType, "application/json")
+        XCTAssertNil(symbol.httpEndpoint)
+    }
+    
+    func testBodyCanBeDecoded() throws {
+        let jsonData = """
+          {
+            "accessLevel" : "public",
+            "identifier" : {
+              "interfaceLanguage" : "data",
+              "precise" : "data:example:get:path1@body=application/json"
+            },
+            "kind" : {
+              "displayName" : "HTTP Body",
+              "identifier" : "httpBody"
+            },
+            "names" : {
+              "title" : "body"
+            },
+            "pathComponents": [],
+            "httpMediaType": "application/json",
+        }
+        """.data(using: .utf8)
+        
+        let decoder = JSONDecoder()
+        let symbol = try decoder.decode(SymbolGraph.Symbol.self, from: jsonData!)
+        
+        XCTAssertEqual(symbol.kind.identifier, .httpBody)
+        XCTAssertEqual(symbol.httpMediaType, "application/json")
+        XCTAssertNil(symbol.httpEndpoint)
+    }
+}


### PR DESCRIPTION
Bug/issue #, if applicable: 

rdar://101408429
rdar://101409112
rdar://101408868
rdar://101408667

## Summary

Add initial support for symbol graphs to model HTTP endpoints.

## Dependencies

None.

## Testing

See instructions in https://github.com/apple/swift-docc/pull/495

## Checklist

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary