### PR TITLE
Add a new initializer to GenericConstraint

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/Swift/GenericConstraint.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Swift/GenericConstraint.swift
@@ -69,6 +69,12 @@ extension SymbolGraph.Symbol.Swift {
          */
         public var rightTypeName: String
 
+        public init(kind: Kind, leftTypeName: String, rightTypeName: String) {
+            self.kind = kind
+            self.leftTypeName = leftTypeName
+            self.rightTypeName = rightTypeName
+        }
+
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             kind = try container.decode(Kind.self, forKey: .kind)

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Swift/GenericConstraint.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Swift/GenericConstraint.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -69,12 +69,14 @@ extension SymbolGraph.Symbol.Swift {
          */
         public var rightTypeName: String
 
+        /// Create a new GenericConstraint for the given kind and type names.
         public init(kind: Kind, leftTypeName: String, rightTypeName: String) {
             self.kind = kind
             self.leftTypeName = leftTypeName
             self.rightTypeName = rightTypeName
         }
 
+        /// Create a new GenericConstraint by decoding a native format.
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             kind = try container.decode(Kind.self, forKey: .kind)
@@ -82,6 +84,7 @@ extension SymbolGraph.Symbol.Swift {
             rightTypeName = try container.decode(String.self, forKey: .rightTypeName)
         }
 
+        /// Encode a GenericConstraint to a native format.
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(kind, forKey: .kind)

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/Swift/GenericConstraintTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/Swift/GenericConstraintTests.swift
@@ -21,9 +21,8 @@ class GenericConstraintTests: XCTestCase {
             "rhs": "Hashable",
         }
         """
-        let jsonData = jsonString.data(using: .utf8)!
+        let jsonData = Data(jsonString.utf8)
         let jsonConstraint = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.GenericConstraint.self, from: jsonData)
-        XCTAssertNotNil(jsonConstraint)
         let constraint = SymbolGraph.Symbol.Swift.GenericConstraint(
             kind: .conformance,
             leftTypeName: "Self",
@@ -40,9 +39,8 @@ class GenericConstraintTests: XCTestCase {
             "rhs": "String",
         }
         """
-        let jsonData = jsonString.data(using: .utf8)!
+        let jsonData = Data(jsonString.utf8)
         let jsonConstraint = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.GenericConstraint.self, from: jsonData)
-        XCTAssertNotNil(jsonConstraint)
         let constraint = SymbolGraph.Symbol.Swift.GenericConstraint(
             kind: .superclass,
             leftTypeName: "Self",
@@ -59,9 +57,8 @@ class GenericConstraintTests: XCTestCase {
             "rhs": "Problem",
         }
         """
-        let jsonData = jsonString.data(using: .utf8)!
+        let jsonData = Data(jsonString.utf8)
         let jsonConstraint = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.GenericConstraint.self, from: jsonData)
-        XCTAssertNotNil(jsonConstraint)
         let constraint = SymbolGraph.Symbol.Swift.GenericConstraint(
             kind: .sameType,
             leftTypeName: "Self",
@@ -69,21 +66,4 @@ class GenericConstraintTests: XCTestCase {
         )
         XCTAssertEqual(jsonConstraint, constraint)
     }
-
-    func testInializeInvalidJSON() {
-        let jsonString = """
-        {
-            "kind": "invalid",
-            "lhs": "Self",
-            "rhs": "Problem",
-        }
-        """
-        let jsonData = jsonString.data(using: .utf8)!
-        do {
-            let _ = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.GenericConstraint.self, from: jsonData)
-            XCTFail("SymbolGraph.Symbol.Swift.GenericConstraint did not raise an exception for invalid JSON")
-        } catch {
-        }
-    }
-
 }

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/Swift/GenericConstraintTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/Swift/GenericConstraintTests.swift
@@ -1,0 +1,89 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+@testable import SymbolKit
+
+class GenericConstraintTests: XCTestCase {
+
+    func testInitializeConformance() throws {
+        let jsonString = """
+        {
+            "kind": "conformance",
+            "lhs": "Self",
+            "rhs": "Hashable",
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let jsonConstraint = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.GenericConstraint.self, from: jsonData)
+        XCTAssertNotNil(jsonConstraint)
+        let constraint = SymbolGraph.Symbol.Swift.GenericConstraint(
+            kind: .conformance,
+            leftTypeName: "Self",
+            rightTypeName: "Hashable"
+        )
+        XCTAssertEqual(jsonConstraint, constraint)
+    }
+
+    func testInitializeSuperclass() throws {
+        let jsonString = """
+        {
+            "kind": "superclass",
+            "lhs": "Self",
+            "rhs": "String",
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let jsonConstraint = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.GenericConstraint.self, from: jsonData)
+        XCTAssertNotNil(jsonConstraint)
+        let constraint = SymbolGraph.Symbol.Swift.GenericConstraint(
+            kind: .superclass,
+            leftTypeName: "Self",
+            rightTypeName: "String"
+        )
+        XCTAssertEqual(jsonConstraint, constraint)
+    }
+
+    func testInitializeSameType() throws {
+        let jsonString = """
+        {
+            "kind": "sameType",
+            "lhs": "Self",
+            "rhs": "Problem",
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let jsonConstraint = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.GenericConstraint.self, from: jsonData)
+        XCTAssertNotNil(jsonConstraint)
+        let constraint = SymbolGraph.Symbol.Swift.GenericConstraint(
+            kind: .sameType,
+            leftTypeName: "Self",
+            rightTypeName: "Problem"
+        )
+        XCTAssertEqual(jsonConstraint, constraint)
+    }
+
+    func testInializeInvalidJSON() {
+        let jsonString = """
+        {
+            "kind": "invalid",
+            "lhs": "Self",
+            "rhs": "Problem",
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        do {
+            let _ = try JSONDecoder().decode(SymbolGraph.Symbol.Swift.GenericConstraint.self, from: jsonData)
+            XCTFail("SymbolGraph.Symbol.Swift.GenericConstraint did not raise an exception for invalid JSON")
+        } catch {
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

Add a new initializer to SymbolGraph.Symbol.Swift.GenericConstraint that allows clients to create these structs directly in memory and not only from decoding JSON.

Swift DocC will use this to in the fix for rdar://112219546.

## Testing

New unit tests were added. The Swift DocC test suite, which exercises this new code path, passes. Swift DocC was used to compile large frameworks without any new problems.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ x ] Added tests
- [ x ] Ran the `./bin/test` script and it succeeded
- ~~[ ] Updated documentation if necessary~~