### PR TITLE
Surface both external and internal names for FunctionParameter values 

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/DeclarationFragments/DeclarationFragments.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/DeclarationFragments/DeclarationFragments.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -155,7 +155,7 @@ extension SymbolGraph.Symbol {
         }
     }
     
-    //// Convenience method to fetch the declaration fragment mixin value.
+    /// Convenience method to fetch the declaration fragment mixin value.
     public var declarationFragments : [DeclarationFragments.Fragment]? {
         (mixins[DeclarationFragments.mixinKey] as? DeclarationFragments)?
             .declarationFragments

--- a/Sources/SymbolKit/SymbolGraph/Symbol/FunctionSignature/FunctionParameter.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/FunctionSignature/FunctionParameter.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -14,13 +14,35 @@ extension SymbolGraph.Symbol.FunctionSignature {
     /// An argument of a callable symbol.
     public struct FunctionParameter: Codable {
         enum CodingKeys: String, CodingKey {
-            case name
+            case externalName = "name"
+            case internalName
             case declarationFragments
             case children
         }
 
-        /// The name of the symbol, as referred to in user code (must match the name used in the documentation comment).
-        public var name: String // should we differentiate between internal and external names?
+        /// The name of the function parameter, as referred to in user code (must match the name used in the documentation comment).
+        public var name: String {
+            get { internalName }
+            set {
+                if _internalName == nil {
+                    externalName = newValue
+                } else {
+                    _internalName = newValue
+                }
+            }
+        }
+        
+        /// The external argument name of the function parameter.
+        public var externalName: String
+        
+        /// The internal parameter name of the function parameter.
+        public var internalName: String {
+            get { _internalName ?? externalName }
+            set { _internalName = newValue }
+        }
+        
+        private var _internalName: String?
+        
         /// The syntax used to create the parameter.
         public var declarationFragments: [SymbolGraph.Symbol.DeclarationFragments.Fragment]
         /// Sub-parameters of the parameter.
@@ -28,16 +50,30 @@ extension SymbolGraph.Symbol.FunctionSignature {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            name = try container.decode(String.self, forKey: .name)
+            externalName = try container.decodeIfPresent(String.self, forKey: .externalName) ?? ""
+            _internalName = try container.decodeIfPresent(String.self, forKey: .internalName)
             declarationFragments = try container.decodeIfPresent([SymbolGraph.Symbol.DeclarationFragments.Fragment].self, forKey: .declarationFragments) ?? []
             children = try container.decodeIfPresent([FunctionParameter].self, forKey: .children) ?? []
         }
 
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(name, forKey: .name)
+            try container.encode(externalName, forKey: .externalName)
+            try container.encodeIfPresent(_internalName, forKey: .internalName)
             try container.encode(declarationFragments, forKey: .declarationFragments)
             try container.encode(children, forKey: .children)
+        }
+        
+        public init(
+            externalName: String,
+            internalName: String?,
+            declarationFragments: [SymbolGraph.Symbol.DeclarationFragments.Fragment],
+            children: [SymbolGraph.Symbol.FunctionSignature.FunctionParameter]
+        ) {
+            self.externalName = externalName
+            self._internalName = internalName == externalName ? nil : internalName
+            self.declarationFragments = declarationFragments
+            self.children = children
         }
     }
 }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/FunctionSignature/FunctionParameter.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/FunctionSignature/FunctionParameter.swift
@@ -14,34 +14,44 @@ extension SymbolGraph.Symbol.FunctionSignature {
     /// An argument of a callable symbol.
     public struct FunctionParameter: Codable {
         enum CodingKeys: String, CodingKey {
-            case externalName = "name"
+            case name
+            case externalName
             case internalName
             case declarationFragments
             case children
         }
 
-        /// The name of the function parameter, as referred to in user code (must match the name used in the documentation comment).
-        public var name: String {
-            get { internalName }
-            set {
-                if _internalName == nil {
-                    externalName = newValue
-                } else {
-                    _internalName = newValue
-                }
-            }
-        }
+        /// The name of the function parameter. This matches how the parameter is referred to a documentation comment.
+        ///
+        /// ## Example
+        ///
+        /// This C function has one parameter where ``name`` is "someValue".
+        ///
+        /// ```c
+        /// void doSomething(int someValue);
+        /// //                   ╰─ name
+        /// ```
+        public var name: String
         
-        /// The external argument name of the function parameter.
-        public var externalName: String
-        
-        /// The internal parameter name of the function parameter.
-        public var internalName: String {
-            get { _internalName ?? externalName }
-            set { _internalName = newValue }
-        }
-        
-        private var _internalName: String?
+        /// The external argument name of the function parameter, if different from the parameter name.
+        ///
+        /// ## Example
+        ///
+        /// In Swift which supports separate argument labels and parameter names, this function has one parameter where ``externalName`` is "with" and ``name`` is "someValue".
+        ///
+        /// ```swift
+        /// func doSomething(with someValue: Int) {}
+        /// //               │    ╰─ name
+        /// //               ╰─ externalName
+        /// ```
+        ///
+        /// A similar function in C, which doesn't separate argument labels from parameter names, has one parameter where ``externalName`` is `nil` and ``name`` is "someValue".
+        ///
+        /// ```c
+        /// void doSomething(int someValue);
+        /// //                   ╰─ name
+        /// ```
+        public var externalName: String?
         
         /// The syntax used to create the parameter.
         public var declarationFragments: [SymbolGraph.Symbol.DeclarationFragments.Fragment]
@@ -50,28 +60,36 @@ extension SymbolGraph.Symbol.FunctionSignature {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            externalName = try container.decodeIfPresent(String.self, forKey: .externalName) ?? ""
-            _internalName = try container.decodeIfPresent(String.self, forKey: .internalName)
+            let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+            if let internalName = try container.decodeIfPresent(String.self, forKey: .internalName) {
+                // Symbol graph generators that emit "name" and "internalName" are remapped to `externalName` and `name`
+                // so that `name` matches how the parameter is referred to in a documentation comment.
+                self.name = internalName
+                self.externalName = name
+            } else {
+                self.name = name
+                self.externalName = try container.decodeIfPresent(String.self, forKey: .externalName)
+            }
             declarationFragments = try container.decodeIfPresent([SymbolGraph.Symbol.DeclarationFragments.Fragment].self, forKey: .declarationFragments) ?? []
             children = try container.decodeIfPresent([FunctionParameter].self, forKey: .children) ?? []
         }
 
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(externalName, forKey: .externalName)
-            try container.encodeIfPresent(_internalName, forKey: .internalName)
+            try container.encode(name, forKey: .name)
+            try container.encodeIfPresent(externalName, forKey: .externalName)
             try container.encode(declarationFragments, forKey: .declarationFragments)
             try container.encode(children, forKey: .children)
         }
         
         public init(
-            externalName: String,
-            internalName: String?,
+            name: String,
+            externalName: String?,
             declarationFragments: [SymbolGraph.Symbol.DeclarationFragments.Fragment],
             children: [SymbolGraph.Symbol.FunctionSignature.FunctionParameter]
         ) {
-            self.externalName = externalName
-            self._internalName = internalName == externalName ? nil : internalName
+            self.name = name
+            self.externalName = externalName == name ? nil : externalName
             self.declarationFragments = declarationFragments
             self.children = children
         }

--- a/Sources/SymbolKit/SymbolGraph/Symbol/FunctionSignature/FunctionSignature.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/FunctionSignature/FunctionSignature.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -46,5 +46,10 @@ extension SymbolGraph.Symbol {
             try container.encode(parameters, forKey: .parameters)
             try container.encode(returns, forKey: .returns)
         }
+    }
+    
+    /// Convenience method to fetch the function signature mixin value.
+    public var functionSignature : FunctionSignature? {
+        (mixins[FunctionSignature.mixinKey] as? FunctionSignature)
     }
 }

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/FunctionSignatureTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/FunctionSignatureTests.swift
@@ -122,10 +122,8 @@ class FunctionSignatureTests: XCTestCase {
         
         let parameter = try XCTUnwrap(functionSignature.parameters.first)
         XCTAssertEqual(parameter.externalName, "with")
-        XCTAssertEqual(parameter.internalName, "someValue")
-        XCTAssertEqual(parameter.declarationFragments.map(\.spelling).joined(), "someValue: Int")
-        
         XCTAssertEqual(parameter.name, "someValue")
+        XCTAssertEqual(parameter.declarationFragments.map(\.spelling).joined(), "someValue: Int")
         
         XCTAssertEqual(functionSignature.returns.count, 1)
         XCTAssertEqual(functionSignature.returns.first?.spelling, "Void")
@@ -139,8 +137,8 @@ class FunctionSignatureTests: XCTestCase {
         let functionSignatureWithDifferentParameterNames = SymbolGraph.Symbol.FunctionSignature(
             parameters: [
                 .init(
+                    name: "parameterName",
                     externalName: "externalName",
-                    internalName: "internalName",
                     declarationFragments: [
                         .init(kind: .identifier, spelling: "internalParam", preciseIdentifier: nil),
                         .init(kind: .text, spelling: ": ", preciseIdentifier: nil),
@@ -177,8 +175,8 @@ class FunctionSignatureTests: XCTestCase {
                       "spelling" : "Int"
                     }
                   ],
-                  "internalName" : "internalName",
-                  "name" : "externalName"
+                  "externalName" : "externalName",
+                  "name" : "parameterName"
                 }
               ],
               "returns" : [
@@ -196,8 +194,8 @@ class FunctionSignatureTests: XCTestCase {
         let functionSignatureWithSameParameterNames = SymbolGraph.Symbol.FunctionSignature(
             parameters: [
                 .init(
+                    name: "externalName",
                     externalName: "externalName",
-                    internalName: "externalName",
                     declarationFragments: [
                         .init(kind: .identifier, spelling: "externalParam", preciseIdentifier: nil),
                         .init(kind: .text, spelling: ": ", preciseIdentifier: nil),
@@ -252,8 +250,8 @@ class FunctionSignatureTests: XCTestCase {
         let functionSignatureWithNoInternalParameterNames = SymbolGraph.Symbol.FunctionSignature(
             parameters: [
                 .init(
-                    externalName: "externalName",
-                    internalName: nil,
+                    name: "externalName",
+                    externalName: nil,
                     declarationFragments: [
                         .init(kind: .identifier, spelling: "externalParam", preciseIdentifier: nil),
                         .init(kind: .text, spelling: ": ", preciseIdentifier: nil),
@@ -299,154 +297,6 @@ class FunctionSignatureTests: XCTestCase {
                   "preciseIdentifier" : "s:s4Voida",
                   "spelling" : "Void"
                 }
-              ]
-            }
-            """
-        )
-    }
-    
-    func testSettingFunctionParameterName() throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        
-        // Different external and internal parameter names
-        var functionSignatureWithDifferentParameterNames = SymbolGraph.Symbol.FunctionSignature(
-            parameters: [
-                .init(
-                    externalName: "externalName",
-                    internalName: "internalName",
-                    declarationFragments: [],
-                    children: []
-                )
-            ],
-            returns: []
-        )
-        functionSignatureWithDifferentParameterNames.parameters[0].name = "newName"
-        
-        let encodedDifferentParameterNames = try XCTUnwrap(String(data: encoder.encode(functionSignatureWithDifferentParameterNames), encoding: .utf8))
-        XCTAssertEqual(encodedDifferentParameterNames, """
-            {
-              "parameters" : [
-                {
-                  "children" : [
-
-                  ],
-                  "declarationFragments" : [
-
-                  ],
-                  "internalName" : "newName",
-                  "name" : "externalName"
-                }
-              ],
-              "returns" : [
-
-              ]
-            }
-            """
-        )
-        
-        // Same external and internal parameter name
-        var functionSignatureWithSameParameterNames = SymbolGraph.Symbol.FunctionSignature(
-            parameters: [
-                .init(
-                    externalName: "externalName",
-                    internalName: "externalName",
-                    declarationFragments: [],
-                    children: []
-                )
-            ],
-            returns: []
-        )
-        functionSignatureWithSameParameterNames.parameters[0].name = "newName"
-            
-        let encodedSameParameterNames = try XCTUnwrap(String(data: encoder.encode(functionSignatureWithSameParameterNames), encoding: .utf8))
-        XCTAssertEqual(encodedSameParameterNames, """
-            {
-              "parameters" : [
-                {
-                  "children" : [
-
-                  ],
-                  "declarationFragments" : [
-
-                  ],
-                  "name" : "newName"
-                }
-              ],
-              "returns" : [
-
-              ]
-            }
-            """
-        )
-        
-        // Initialized with no internal name
-        var functionSignatureWithNoInternalParameterNames = SymbolGraph.Symbol.FunctionSignature(
-            parameters: [
-                .init(
-                    externalName: "externalName",
-                    internalName: nil,
-                    declarationFragments: [],
-                    children: []
-                )
-            ],
-            returns: []
-        )
-        functionSignatureWithNoInternalParameterNames.parameters[0].name = "newName"
-        
-        let encodedNoInternalParameterName = try XCTUnwrap(String(data: encoder.encode(functionSignatureWithNoInternalParameterNames), encoding: .utf8))
-        XCTAssertEqual(encodedNoInternalParameterName, """
-            {
-              "parameters" : [
-                {
-                  "children" : [
-
-                  ],
-                  "declarationFragments" : [
-
-                  ],
-                  "name" : "newName"
-                }
-              ],
-              "returns" : [
-
-              ]
-            }
-            """
-        )
-        
-        // Different external and internal parameter names
-        var functionSignatureInternalParameterNameSetAfterInitialization = SymbolGraph.Symbol.FunctionSignature(
-            parameters: [
-                .init(
-                    externalName: "externalName",
-                    internalName: nil,
-                    declarationFragments: [],
-                    children: []
-                )
-            ],
-            returns: []
-        )
-        functionSignatureInternalParameterNameSetAfterInitialization.parameters[0].internalName = "newInternalName"
-        functionSignatureInternalParameterNameSetAfterInitialization.parameters[0].name = "newName"
-        
-        let encodedInternalParameterNameSetAfterInitialization = try XCTUnwrap(String(data: encoder.encode(functionSignatureInternalParameterNameSetAfterInitialization), encoding: .utf8))
-        XCTAssertEqual(encodedInternalParameterNameSetAfterInitialization, """
-            {
-              "parameters" : [
-                {
-                  "children" : [
-
-                  ],
-                  "declarationFragments" : [
-
-                  ],
-                  "internalName" : "newName",
-                  "name" : "externalName"
-                }
-              ],
-              "returns" : [
-
               ]
             }
             """

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/FunctionSignatureTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/FunctionSignatureTests.swift
@@ -1,0 +1,456 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See https://swift.org/LICENSE.txt for license information
+ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import SymbolKit
+
+class FunctionSignatureTests: XCTestCase {
+    func testDecoding() throws {
+        let jsonData = """
+{
+  "kind": {
+    "identifier": "swift.func",
+    "displayName": "Function"
+  },
+  "identifier": {
+    "precise": "s:9Something02doA04withySi_tF",
+    "interfaceLanguage": "swift"
+  },
+  "pathComponents": [
+    "doSomething(with:)"
+  ],
+  "names": {
+    "title": "doSomething(with:)"
+  },
+  "functionSignature": {
+    "parameters": [
+      {
+        "name": "with",
+        "internalName": "someValue",
+        "declarationFragments": [
+          {
+            "kind": "identifier",
+            "spelling": "someValue"
+          },
+          {
+            "kind": "text",
+            "spelling": ": "
+          },
+          {
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+          }
+        ]
+      }
+    ],
+    "returns": [
+      {
+        "kind": "typeIdentifier",
+        "spelling": "Void",
+        "preciseIdentifier": "s:s4Voida"
+      }
+    ]
+  },
+  "declarationFragments": [
+    {
+      "kind": "keyword",
+      "spelling": "func"
+    },
+    {
+      "kind": "text",
+      "spelling": " "
+    },
+    {
+      "kind": "identifier",
+      "spelling": "doSomething"
+    },
+    {
+      "kind": "text",
+      "spelling": "("
+    },
+    {
+      "kind": "externalParam",
+      "spelling": "with"
+    },
+    {
+      "kind": "text",
+      "spelling": " "
+    },
+    {
+      "kind": "internalParam",
+      "spelling": "someValue"
+    },
+    {
+      "kind": "text",
+      "spelling": ": "
+    },
+    {
+      "kind": "typeIdentifier",
+      "spelling": "Int",
+      "preciseIdentifier": "s:Si"
+    },
+    {
+      "kind": "text",
+      "spelling": ")"
+    }
+  ],
+  "accessLevel": "public",
+  "location": {
+    "uri": "file:///Users/username/path/to/SomeFile.swift",
+    "position": {
+      "line": 9,
+      "character": 12
+    }
+  }
+}
+""".data(using: .utf8)
+        
+        let decoder = JSONDecoder()
+        let symbol = try decoder.decode(SymbolGraph.Symbol.self, from: jsonData!)
+        
+        let functionSignature = try XCTUnwrap(symbol.functionSignature)
+        
+        XCTAssertEqual(functionSignature.parameters.count, 1)
+        
+        let parameter = try XCTUnwrap(functionSignature.parameters.first)
+        XCTAssertEqual(parameter.externalName, "with")
+        XCTAssertEqual(parameter.internalName, "someValue")
+        XCTAssertEqual(parameter.declarationFragments.map(\.spelling).joined(), "someValue: Int")
+        
+        XCTAssertEqual(parameter.name, "someValue")
+        
+        XCTAssertEqual(functionSignature.returns.count, 1)
+        XCTAssertEqual(functionSignature.returns.first?.spelling, "Void")
+    }
+    
+    func testEncoding() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        
+        // Different external and internal parameter names
+        let functionSignatureWithDifferentParameterNames = SymbolGraph.Symbol.FunctionSignature(
+            parameters: [
+                .init(
+                    externalName: "externalName",
+                    internalName: "internalName",
+                    declarationFragments: [
+                        .init(kind: .identifier, spelling: "internalParam", preciseIdentifier: nil),
+                        .init(kind: .text, spelling: ": ", preciseIdentifier: nil),
+                        .init(kind: .typeIdentifier, spelling: "Int", preciseIdentifier: "s:Si"),
+                    ],
+                    children: []
+                )
+            ],
+            returns: [
+                .init(kind: .typeIdentifier, spelling: "Void", preciseIdentifier: "s:s4Voida")
+            ]
+        )
+        
+        let encodedDifferentParameterNames = try XCTUnwrap(String(data: encoder.encode(functionSignatureWithDifferentParameterNames), encoding: .utf8))
+        XCTAssertEqual(encodedDifferentParameterNames, """
+            {
+              "parameters" : [
+                {
+                  "children" : [
+
+                  ],
+                  "declarationFragments" : [
+                    {
+                      "kind" : "identifier",
+                      "spelling" : "internalParam"
+                    },
+                    {
+                      "kind" : "text",
+                      "spelling" : ": "
+                    },
+                    {
+                      "kind" : "typeIdentifier",
+                      "preciseIdentifier" : "s:Si",
+                      "spelling" : "Int"
+                    }
+                  ],
+                  "internalName" : "internalName",
+                  "name" : "externalName"
+                }
+              ],
+              "returns" : [
+                {
+                  "kind" : "typeIdentifier",
+                  "preciseIdentifier" : "s:s4Voida",
+                  "spelling" : "Void"
+                }
+              ]
+            }
+            """
+        )
+        
+        // Same external and internal parameter name
+        let functionSignatureWithSameParameterNames = SymbolGraph.Symbol.FunctionSignature(
+            parameters: [
+                .init(
+                    externalName: "externalName",
+                    internalName: "externalName",
+                    declarationFragments: [
+                        .init(kind: .identifier, spelling: "externalParam", preciseIdentifier: nil),
+                        .init(kind: .text, spelling: ": ", preciseIdentifier: nil),
+                        .init(kind: .typeIdentifier, spelling: "Int", preciseIdentifier: "s:Si"),
+                    ],
+                    children: []
+                )
+            ],
+            returns: [
+                .init(kind: .typeIdentifier, spelling: "Void", preciseIdentifier: "s:s4Voida")
+            ]
+        )
+        
+        let encodedSameParameterNames = try XCTUnwrap(String(data: encoder.encode(functionSignatureWithSameParameterNames), encoding: .utf8))
+        XCTAssertEqual(encodedSameParameterNames, """
+            {
+              "parameters" : [
+                {
+                  "children" : [
+
+                  ],
+                  "declarationFragments" : [
+                    {
+                      "kind" : "identifier",
+                      "spelling" : "externalParam"
+                    },
+                    {
+                      "kind" : "text",
+                      "spelling" : ": "
+                    },
+                    {
+                      "kind" : "typeIdentifier",
+                      "preciseIdentifier" : "s:Si",
+                      "spelling" : "Int"
+                    }
+                  ],
+                  "name" : "externalName"
+                }
+              ],
+              "returns" : [
+                {
+                  "kind" : "typeIdentifier",
+                  "preciseIdentifier" : "s:s4Voida",
+                  "spelling" : "Void"
+                }
+              ]
+            }
+            """
+        )
+        
+        // Initialized with no internal name
+        let functionSignatureWithNoInternalParameterNames = SymbolGraph.Symbol.FunctionSignature(
+            parameters: [
+                .init(
+                    externalName: "externalName",
+                    internalName: nil,
+                    declarationFragments: [
+                        .init(kind: .identifier, spelling: "externalParam", preciseIdentifier: nil),
+                        .init(kind: .text, spelling: ": ", preciseIdentifier: nil),
+                        .init(kind: .typeIdentifier, spelling: "Int", preciseIdentifier: "s:Si"),
+                    ],
+                    children: []
+                )
+            ],
+            returns: [
+                .init(kind: .typeIdentifier, spelling: "Void", preciseIdentifier: "s:s4Voida")
+            ]
+        )
+        
+        let encodedNoInternalParameterName = try XCTUnwrap(String(data: encoder.encode(functionSignatureWithNoInternalParameterNames), encoding: .utf8))
+        XCTAssertEqual(encodedNoInternalParameterName, """
+            {
+              "parameters" : [
+                {
+                  "children" : [
+
+                  ],
+                  "declarationFragments" : [
+                    {
+                      "kind" : "identifier",
+                      "spelling" : "externalParam"
+                    },
+                    {
+                      "kind" : "text",
+                      "spelling" : ": "
+                    },
+                    {
+                      "kind" : "typeIdentifier",
+                      "preciseIdentifier" : "s:Si",
+                      "spelling" : "Int"
+                    }
+                  ],
+                  "name" : "externalName"
+                }
+              ],
+              "returns" : [
+                {
+                  "kind" : "typeIdentifier",
+                  "preciseIdentifier" : "s:s4Voida",
+                  "spelling" : "Void"
+                }
+              ]
+            }
+            """
+        )
+    }
+    
+    func testSettingFunctionParameterName() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        
+        // Different external and internal parameter names
+        var functionSignatureWithDifferentParameterNames = SymbolGraph.Symbol.FunctionSignature(
+            parameters: [
+                .init(
+                    externalName: "externalName",
+                    internalName: "internalName",
+                    declarationFragments: [],
+                    children: []
+                )
+            ],
+            returns: []
+        )
+        functionSignatureWithDifferentParameterNames.parameters[0].name = "newName"
+        
+        let encodedDifferentParameterNames = try XCTUnwrap(String(data: encoder.encode(functionSignatureWithDifferentParameterNames), encoding: .utf8))
+        XCTAssertEqual(encodedDifferentParameterNames, """
+            {
+              "parameters" : [
+                {
+                  "children" : [
+
+                  ],
+                  "declarationFragments" : [
+
+                  ],
+                  "internalName" : "newName",
+                  "name" : "externalName"
+                }
+              ],
+              "returns" : [
+
+              ]
+            }
+            """
+        )
+        
+        // Same external and internal parameter name
+        var functionSignatureWithSameParameterNames = SymbolGraph.Symbol.FunctionSignature(
+            parameters: [
+                .init(
+                    externalName: "externalName",
+                    internalName: "externalName",
+                    declarationFragments: [],
+                    children: []
+                )
+            ],
+            returns: []
+        )
+        functionSignatureWithSameParameterNames.parameters[0].name = "newName"
+            
+        let encodedSameParameterNames = try XCTUnwrap(String(data: encoder.encode(functionSignatureWithSameParameterNames), encoding: .utf8))
+        XCTAssertEqual(encodedSameParameterNames, """
+            {
+              "parameters" : [
+                {
+                  "children" : [
+
+                  ],
+                  "declarationFragments" : [
+
+                  ],
+                  "name" : "newName"
+                }
+              ],
+              "returns" : [
+
+              ]
+            }
+            """
+        )
+        
+        // Initialized with no internal name
+        var functionSignatureWithNoInternalParameterNames = SymbolGraph.Symbol.FunctionSignature(
+            parameters: [
+                .init(
+                    externalName: "externalName",
+                    internalName: nil,
+                    declarationFragments: [],
+                    children: []
+                )
+            ],
+            returns: []
+        )
+        functionSignatureWithNoInternalParameterNames.parameters[0].name = "newName"
+        
+        let encodedNoInternalParameterName = try XCTUnwrap(String(data: encoder.encode(functionSignatureWithNoInternalParameterNames), encoding: .utf8))
+        XCTAssertEqual(encodedNoInternalParameterName, """
+            {
+              "parameters" : [
+                {
+                  "children" : [
+
+                  ],
+                  "declarationFragments" : [
+
+                  ],
+                  "name" : "newName"
+                }
+              ],
+              "returns" : [
+
+              ]
+            }
+            """
+        )
+        
+        // Different external and internal parameter names
+        var functionSignatureInternalParameterNameSetAfterInitialization = SymbolGraph.Symbol.FunctionSignature(
+            parameters: [
+                .init(
+                    externalName: "externalName",
+                    internalName: nil,
+                    declarationFragments: [],
+                    children: []
+                )
+            ],
+            returns: []
+        )
+        functionSignatureInternalParameterNameSetAfterInitialization.parameters[0].internalName = "newInternalName"
+        functionSignatureInternalParameterNameSetAfterInitialization.parameters[0].name = "newName"
+        
+        let encodedInternalParameterNameSetAfterInitialization = try XCTUnwrap(String(data: encoder.encode(functionSignatureInternalParameterNameSetAfterInitialization), encoding: .utf8))
+        XCTAssertEqual(encodedInternalParameterNameSetAfterInitialization, """
+            {
+              "parameters" : [
+                {
+                  "children" : [
+
+                  ],
+                  "declarationFragments" : [
+
+                  ],
+                  "internalName" : "newName",
+                  "name" : "externalName"
+                }
+              ],
+              "returns" : [
+
+              ]
+            }
+            """
+        )
+    }
+}
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -552,11 +552,11 @@ components:
         - declaration
       properties:
         name:
-          description: The external argument name.
+          description: The parameter name.
           type: string
           nullable: true
-        internalName:
-          description: The internal parameter name, if different from the external name.
+        externalName:
+          description: The external argument name, if different from the parameter name.
           type: string
           nullable: true
         declaration:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -552,6 +552,11 @@ components:
         - declaration
       properties:
         name:
+          description: The external argument name.
+          type: string
+          nullable: true
+        internalName:
+          description: The internal parameter name, if different from the external name.
           type: string
           nullable: true
         declaration:


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This surface both the external "argument name" and the internal "parameter name" for FunctionParameter values. 

The JSON key used for the internal name is "internalName", based on [what the Swift symbol graph extractor emits](https://github.com/apple/swift/blob/main/lib/SymbolGraphGen/Symbol.cpp#L422-L430).

With two different names to pick from, this updates the `name` property to behave as its documented:

> The name of the function parameter, as referred to in user code (must match the name used in the documentation comment).

Since it's the internal name that's used in user code and in the documentation comment, `name` returns `internalName`.

If the parameter has both an external "argument name" and an internal "parameter name", then `name` returns the internal "parameter name" and `externalName` returns the external "argument name".

## Dependencies

None

## Testing

- Extract a symbol graph file for 
  ```swift
  public func doSomething(with someValue: Int) { }
  ```
  
- Decode that symbol graph file. 
  - The function's parameter's `name` should be "someValue" 
  - The function's parameter's `externalName` should be "with"

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary