### PR TITLE
add a new 'namespace' symbol kind

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -46,7 +46,9 @@ extension SymbolGraph.Symbol {
         public static let macro = KindIdentifier(rawValue: "macro")
         
         public static let method = KindIdentifier(rawValue: "method")
-        
+
+        public static let namespace = KindIdentifier(rawValue: "namespace")
+
         public static let property = KindIdentifier(rawValue: "property")
         
         public static let `protocol` = KindIdentifier(rawValue: "protocol")
@@ -108,6 +110,7 @@ extension SymbolGraph.Symbol {
             Self.ivar.rawValue: .ivar,
             Self.macro.rawValue: .macro,
             Self.method.rawValue: .method,
+            Self.namespace.rawValue: .namespace,
             Self.property.rawValue: .property,
             Self.protocol.rawValue: .protocol,
             Self.snippet.rawValue: .snippet,


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://117904480

## Summary

In order to support Clang's C++ symbol graphs, SymbolKit needs to be aware of `namespace` symbols, which use a new symbol kind. This PR adds a `namespace` symbol kind to accommodate them.

## Dependencies

None

## Testing

Ensure that a symbol graph generated from Clang that contains C++ namespaces correctly uses the new symbol kind. This is tested more thoroughly in the corresponding Swift-DocC PR.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests (Parsing/saving of symbol kinds is already tested in `SymbolKindTests.testKindIdentifierRoundTrip`)
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary