### PR TITLE
add support for 'union' symbols

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -68,7 +68,9 @@ extension SymbolGraph.Symbol {
         public static let typeSubscript = KindIdentifier(rawValue: "type.subscript")
         
         public static let `typealias` = KindIdentifier(rawValue: "typealias")
-        
+
+        public static let union = KindIdentifier(rawValue: "union")
+
         public static let `var` = KindIdentifier(rawValue: "var")
         
         public static let module = KindIdentifier(rawValue: "module")
@@ -121,6 +123,7 @@ extension SymbolGraph.Symbol {
             Self.typeProperty.rawValue: .typeProperty,
             Self.typeSubscript.rawValue: .typeSubscript,
             Self.typealias.rawValue: .typealias,
+            Self.union.rawValue: .union,
             Self.var.rawValue: .var,
             Self.module.rawValue: .module,
             Self.extension.rawValue: .extension,


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://119722462

## Summary

Clang's upcoming C++ support changed how C unions are represented in the symbol graph by giving them their own `union` symbol kind. This PR adds support for dedicated `union` symbols.

## Dependencies

None

## Testing

See instructions on the Swift-DocC PR: https://github.com/apple/swift-docc/pull/785

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ n/a ] Added tests (symbol kind round-trip encoding is already tested in `SymbolKindTests.testKindIdentifierRoundTrip`)
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary