### PR TITLE
Fix typos in documentation.

### DIFF
--- a/Sources/SymbolKit/Mixin/Mixin+Equals.swift
+++ b/Sources/SymbolKit/Mixin/Mixin+Equals.swift
@@ -11,19 +11,19 @@
 import Foundation
 
 // `Mixin` does not conform to `Equatable` right now primarily because
-// this would complicate its usage in many situtations because of "Self
+// this would complicate its usage in many situations because of "Self
 // or associated type" requirements errors. Thus, in order to compare
 // `Mixin`s for equality, we need to somehow get access to the `Mixin`'s
 // `Equatable` conformance and the `==(lhs:rhs:)` function specifically.
 //
-// Note that all of this would be siginificantly easier in Swift 5.7, so
+// Note that all of this would be significantly easier in Swift 5.7, so
 // it might be worth updating the implementation once SymbolKit adopts
 // Swift 5.7 as its minimum language requirement.
 
 
 // When working with `Mixin` values in a generic (non-specific) context,
 // we only know their value conforms to the existential type `Mixin`. This
-// extension to `Mixin` and the `equals` property defined in it is essentiall for
+// extension to `Mixin` and the `equals` property defined in it is essential for
 // the whole process to work:
 // The `equals` property does not expose the `Self` type in its interface and
 // therefore is accessible from the existential type `Mixin`. Inside `equals`,

--- a/Sources/SymbolKit/Mixin/Mixin+Hash.swift
+++ b/Sources/SymbolKit/Mixin/Mixin+Hash.swift
@@ -11,21 +11,21 @@
 import Foundation
 
 // `Mixin` does not conform to `Hashable` right now primarily because
-// this would complicate its usage in many situtations because of "Self
+// this would complicate its usage in many situations because of "Self
 // or associated type" requirements errors. `Hashable` inherits those
 // frome `Equatable`, even though its primary functionality, the `hash(into:)`
 // function has no Self or associated type requirements. Thus, in order to
 // access a `Mixin`'s `hash(into:)` function, we need to somehow get access to
 // the `Mixin`'s `Hashable` conformance.
 //
-// Note that all of this would be siginificantly easier in Swift 5.7, so
+// Note that all of this would be significantly easier in Swift 5.7, so
 // it might be worth updating the implementation once SymbolKit adopts
 // Swift 5.7 as its minimum language requirement.
 
 
 // When working with `Mixin` values in a generic (non-specific) context,
 // we only know their value conforms to the existential type `Mixin`. This
-// extension to `Mixin` and the `hash` property defined in it is essentiall for
+// extension to `Mixin` and the `hash` property defined in it is essential for
 // the whole process to work:
 // The `hash` property does not expose the `Self` type in its interface and
 // therefore is accessible from the existential type `Mixin`. Inside `hash`,

--- a/Sources/SymbolKit/Mixin/Mixin.swift
+++ b/Sources/SymbolKit/Mixin/Mixin.swift
@@ -101,7 +101,7 @@ extension MixinCodingInformation {
 public protocol SingleValueMixin: Mixin {
     /// The type of the wrapped value.
     associatedtype ValueType: Codable
-    /// The property holded the encoded/decoded value.
+    /// The property holding the encoded/decoded value.
     var value: ValueType { get set }
     /// The constructor for the concrete type, taking just the wrapped value as its argument.
     init(_: ValueType)

--- a/Sources/SymbolKit/SymbolGraph/Module.swift
+++ b/Sources/SymbolKit/SymbolGraph/Module.swift
@@ -22,7 +22,7 @@ extension SymbolGraph {
         /// The platform intended for deployment.
         public var platform: Platform
 
-        /// The [semantic version](https://semver.org) of the module, if availble.
+        /// The [semantic version](https://semver.org) of the module, if available.
         public var version: SemanticVersion?
 
         /// `true` if the module represents a virtual module, not created from source,

--- a/Sources/SymbolKit/SymbolGraph/Relationship/Relationship.swift
+++ b/Sources/SymbolKit/SymbolGraph/Relationship/Relationship.swift
@@ -145,7 +145,7 @@ extension SymbolGraph.Relationship {
     /// decoding relationships.
     ///
     /// If ``SymbolGraph/Relationship`` does not know the concrete type of a ``Mixin``, it cannot encode
-    /// or decode that type and thus skipps such entries. Note that ``Mixin``s that occur on relationships
+    /// or decode that type and thus skips such entries. Note that ``Mixin``s that occur on relationships
     /// in the default symbol graph format do not have to be registered!
     ///
     /// - Parameter userInfo: A property which allows editing the `userInfo` member of the
@@ -154,7 +154,7 @@ extension SymbolGraph.Relationship {
     /// You can log warnings and either re-throw or consume the error.
     /// - Parameter onDecodingError: Defines the behavior when an error occurs while decoding these types of ``Mixin``s.
     /// Next to logging warnings, the function allows for either re-throwing the error,
-    /// skipping the errornous entry, or providing a default value.
+    /// skipping the erroneous entry, or providing a default value.
     public static func register<M: Sequence>(mixins mixinTypes: M,
                                              to userInfo: inout [CodingUserInfoKey: Any],
                                              onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)?,
@@ -181,14 +181,14 @@ public extension JSONEncoder {
     /// Register types conforming to ``Mixin`` so they can be included when encoding relationships.
     ///
     /// If ``SymbolGraph/Relationship`` does not know the concrete type of a ``Mixin``, it cannot encode
-    /// that type and thus skipps such entries. Note that ``Mixin``s that occur on relationships
+    /// that type and thus skips such entries. Note that ``Mixin``s that occur on relationships
     /// in the default symbol graph format do not have to be registered!
     ///
     /// - Parameter onEncodingError: Defines the behavior when an error occurs while encoding these types of ``Mixin``s.
     /// You can log warnings and either re-throw or consume the error.
     /// - Parameter onDecodingError: Defines the behavior when an error occurs while decoding these types of ``Mixin``s.
     /// Next to logging warnings, the function allows for either re-throwing the error,
-    /// skipping the errornous entry, or providing a default value.
+    /// skipping the erroneous entry, or providing a default value.
     func register(relationshipMixins mixinTypes: Mixin.Type...,
                   onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)? = nil,
                   onDecodingError: ((_ error: Error) throws -> Mixin?)? = nil) {
@@ -203,14 +203,14 @@ public extension JSONDecoder {
     /// Register types conforming to ``Mixin`` so they can be included when decoding relationships.
     ///
     /// If ``SymbolGraph/Relationship`` does not know the concrete type of a ``Mixin``, it cannot decode
-    /// that type and thus skipps such entries. Note that ``Mixin``s that occur on relationships
+    /// that type and thus skips such entries. Note that ``Mixin``s that occur on relationships
     /// in the default symbol graph format do not have to be registered!
     ///
     /// - Parameter onEncodingError: Defines the behavior when an error occurs while encoding these types of ``Mixin``s.
     /// You can log warnings and either re-throw or consume the error.
     /// - Parameter onDecodingError: Defines the behavior when an error occurs while decoding these types of ``Mixin``s.
     /// Next to logging warnings, the function allows for either re-throwing the error,
-    /// skipping the errornous entry, or providing a default value.
+    /// skipping the erroneous entry, or providing a default value.
     func register(relationshipMixins mixinTypes: Mixin.Type...,
                   onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)? = nil,
                   onDecodingError: ((_ error: Error) throws -> Mixin?)? = nil) {
@@ -259,7 +259,7 @@ extension SymbolGraph.Relationship: Hashable, Equatable {
         }
     }
 
-    /// A custom equality implmentation for a relationship.
+    /// A custom equality implementation for a relationship.
     ///
     /// - Note: ``Mixin``s that do not conform to `Equatable` will be ignored entirely, including their count and
     /// ``Mixin/mixinKey``.

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Availability.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Availability.swift
@@ -20,7 +20,7 @@ extension SymbolGraph.Symbol {
      For example,
      a class introduced in iOS 11 would have:
 
-     - a availability domain of `"iOS"` and
+     - an availability domain of `"iOS"` and
      - an `introduced` version of `11.0.0`.
 
      As another example,

--- a/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/KindIdentifier.swift
@@ -19,7 +19,7 @@ extension SymbolGraph.Symbol {
         
         /// Create a new ``SymbolGraph/Symbol/KindIdentifier``.
         ///
-        /// - Note: Only use this initilaizer for defining a new kind. For initializing instances manually,
+        /// - Note: Only use this initializer for defining a new kind. For initializing instances manually,
         /// copy the initial initializer. For extracting identifiers form raw strings, use ``init(identifier:)``.
         public init(rawValue: String) {
             self.rawValue = rawValue

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Symbol.swift
@@ -285,7 +285,7 @@ extension SymbolGraph.Symbol {
     /// decoding symbols.
     ///
     /// If ``SymbolGraph/Symbol`` does not know the concrete type of a ``Mixin``, it cannot encode
-    /// or decode that type and thus skipps such entries. Note that ``Mixin``s that occur on symbols
+    /// or decode that type and thus skips such entries. Note that ``Mixin``s that occur on symbols
     /// in the default symbol graph format do not have to be registered!
     ///
     /// - Parameter userInfo: A property which allows editing the `userInfo` member of the
@@ -294,7 +294,7 @@ extension SymbolGraph.Symbol {
     /// You can log warnings and either re-throw or consume the error.
     /// - Parameter onDecodingError: Defines the behavior when an error occurs while decoding these types of ``Mixin``s.
     /// Next to logging warnings, the function allows for either re-throwing the error,
-    /// skipping the errornous entry, or providing a default value.
+    /// skipping the erroneous entry, or providing a default value.
     public static func register<M: Sequence>(mixins mixinTypes: M,
                                              to userInfo: inout [CodingUserInfoKey: Any],
                                              onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)?,
@@ -322,14 +322,14 @@ public extension JSONEncoder {
     /// Register types conforming to ``Mixin`` so they can be included when encoding symbols.
     ///
     /// If ``SymbolGraph/Symbol`` does not know the concrete type of a ``Mixin``, it cannot encode
-    /// that type and thus skipps such entries. Note that ``Mixin``s that occur on symbols
+    /// that type and thus skips such entries. Note that ``Mixin``s that occur on symbols
     /// in the default symbol graph format do not have to be registered!
     ///
     /// - Parameter onEncodingError: Defines the behavior when an error occurs while encoding these types of ``Mixin``s.
     /// You can log warnings and either re-throw or consume the error.
     /// - Parameter onDecodingError: Defines the behavior when an error occurs while decoding these types of ``Mixin``s.
     /// Next to logging warnings, the function allows for either re-throwing the error,
-    /// skipping the errornous entry, or providing a default value.
+    /// skipping the erroneous entry, or providing a default value.
     func register(symbolMixins mixinTypes: Mixin.Type...,
                   onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)? = nil,
                   onDecodingError: ((_ error: Error) throws -> Mixin?)? = nil) {
@@ -344,14 +344,14 @@ public extension JSONDecoder {
     /// Register types conforming to ``Mixin`` so they can be included when decoding symbols.
     ///
     /// If ``SymbolGraph/Symbol`` does not know the concrete type of a ``Mixin``, it cannot decode
-    /// that type and thus skipps such entries. Note that ``Mixin``s that occur on symbols
+    /// that type and thus skips such entries. Note that ``Mixin``s that occur on symbols
     /// in the default symbol graph format do not have to be registered!
     ///
     /// - Parameter onEncodingError: Defines the behavior when an error occurs while encoding these types of ``Mixin``s.
     /// You can log warnings and either re-throw or consume the error.
     /// - Parameter onDecodingError: Defines the behavior when an error occurs while decoding these types of ``Mixin``s.
     /// Next to logging warnings, the function allows for either re-throwing the error,
-    /// skipping the errornous entry, or providing a default value.
+    /// skipping the erroneous entry, or providing a default value.
     func register(symbolMixins mixinTypes: Mixin.Type...,
                   onEncodingError: ((_ error: Error, _ mixin: Mixin) throws -> Void)? = nil,
                   onDecodingError: ((_ error: Error) throws -> Mixin?)? = nil) {

--- a/Sources/SymbolKit/SymbolKit.docc/GraphFormatExtensions.md
+++ b/Sources/SymbolKit/SymbolKit.docc/GraphFormatExtensions.md
@@ -4,7 +4,7 @@ Define custom Symbol or Relationship kinds and store custom information in the g
 
 ## Overview
 
-SymbolKit makes it easy to parse Symbol Graph Files and inspect or edit the resulting graph's _contents_. However, sometimes you migth want to go beyond that by changing the _structure_ of the graph. SymbolKit allows you to define custom Symbol and Relationship kinds and lets you extend nodes and edges with custom properties.
+SymbolKit makes it easy to parse Symbol Graph Files and inspect or edit the resulting graph's _contents_. However, sometimes you might want to go beyond that by changing the _structure_ of the graph. SymbolKit allows you to define custom Symbol and Relationship kinds and lets you extend nodes and edges with custom properties.
 
 ## Defining Custom Symbol or Relationship Kinds
 
@@ -22,7 +22,7 @@ extension SymbolGraph.Relationship.Kind {
 }
 ```
 
-Use these constants when manually initializing Symbols/Relationships of the respective kind instead of initilaizing new instances of ``SymbolGraph/Symbol/KindIdentifier`` / ``SymbolGraph/Relationship/Kind-swift.struct`` all the time.
+Use these constants when manually initializing Symbols/Relationships of the respective kind instead of initializing new instances of ``SymbolGraph/Symbol/KindIdentifier`` / ``SymbolGraph/Relationship/Kind-swift.struct`` all the time.
 
 After defining a custom Symbol kind, make sure to register it using ``SymbolGraph/Symbol/KindIdentifier/register(_:)``. This ensures all static functionality defined on ``SymbolGraph/Symbol/KindIdentifier`` works as expected.
 
@@ -42,7 +42,7 @@ Start out by defining the information you want to capture:
 ```swift
 /// Commit metadata of the last commit that modified this Symbol.
 struct LastCommit: Mixin, Hashable {
-    static let mixinKey = "lastCommit"    
+    static let mixinKey = "lastCommit"
 
     let hash: String
     let date: Date
@@ -70,7 +70,7 @@ You can now easily edit this information on an existing Symbol Graph.
 
 Before you can encode and decode this information, you need to register your custom Mixin on your encoder/decoder using ``SymbolGraph/Symbol/register(mixins:to:onEncodingError:onDecodingError:)`` (for ``SymbolGraph/Symbol``) or ``SymbolGraph/Relationship/register(mixins:to:onEncodingError:onDecodingError:)`` (for ``SymbolGraph/Relationship``). If you forget this step, you custom mixins will be ignored!
 
-- Note: There exist handy shorcuts on Foundation's `JSONEncoder` and `JSONDecoder` for all the registration functions.
+- Note: There exist handy shortcuts on Foundation's `JSONEncoder` and `JSONDecoder` for all the registration functions.
 
 ```swift
 // prepare encoder and decoder to deal with custom mixin

--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -31,7 +31,7 @@ public class GraphCollector {
 
     /// Initialize a new collector for merging ``SymbolGraph``s into ``UnifiedSymbolGraph``s.
     ///
-    /// - Parameter extensionGraphAssociationStrategy: Optionally specifiy how extension graphs are to be merged.
+    /// - Parameter extensionGraphAssociationStrategy: Optionally specify how extension graphs are to be merged.
     public init(extensionGraphAssociationStrategy: ExtensionGraphAssociation = .extendedGraph) {
         self.unifiedGraphs = [:]
         self.graphSources = [:]

--- a/Tests/SymbolKitTests/SymbolGraph/Relationship/HashableTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Relationship/HashableTests.swift
@@ -13,7 +13,7 @@ import XCTest
 import SymbolKit
 
 class HashableTests: XCTestCase {
-    /// Test hasing works as expected if Mixins conform to Hashable
+    /// Test hashing works as expected if Mixins conform to Hashable
     func testHashingWithHashableMixins() throws {
         var a1 = SymbolGraph.Relationship(source: "a.source", target: "a.target", kind: .conformsTo, targetFallback: nil)
         a1.mixins[SymbolGraph.Relationship.SourceOrigin.mixinKey] = SymbolGraph.Relationship.SourceOrigin(identifier: "a.1.origin", displayName: "a.1.origin")
@@ -87,7 +87,7 @@ class HashableTests: XCTestCase {
         // only iterates over the `lhs` mixins. Thus, depending on what relationship comes out
         // as the `lhs`, the equality might fail at different times (though it will always fail).
         // In this example, if `a1` is `lhs`, the comparison for `"a"` will be skipped (since the
-        // lhs is not `Equatable`), but the comparision for `"b"` will return false.
+        // lhs is not `Equatable`), but the comparison for `"b"` will return false.
         // In contrast, if `a2` is `lhs`, the comparison for `"a"` will return false right away.
         a1 = SymbolGraph.Relationship(source: "a.source", target: "a.target", kind: .conformsTo, targetFallback: nil)
         a1.mixins["a"] = NotHashableMixin(value: "a.1.value")

--- a/Tests/SymbolKitTests/SymbolGraph/Symbol/SymbolKindTests.swift
+++ b/Tests/SymbolKitTests/SymbolGraph/Symbol/SymbolKindTests.swift
@@ -56,7 +56,7 @@ class SymbolKindTests: XCTestCase {
         XCTAssertEqual(kind.identifier, "custom")
         
         // Verify an unknown identifier is parsed correctly if it is
-        // registered with the deocder.
+        // registered with the decoder.
         let otherCustom = SymbolGraph.Symbol.KindIdentifier(rawValue: "other.custom")
         let decoder = JSONDecoder()
         decoder.register(symbolKinds: otherCustom)

--- a/bin/check-source
+++ b/bin/check-source
@@ -44,7 +44,7 @@ for language in swift-or-c bash md-or-tutorial html docker; do
   declare -a matching_files
   declare -a exceptions
   declare -a reader
-  expections=( )
+  exceptions=( )
   matching_files=( -name '*' )
   reader=head
   case "$language" in


### PR DESCRIPTION
## Summary

Fix several typos in documentation. No code changes.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (Not applicable.)
- [x] Ran the `./bin/test` script and it succeeded
- [ ] ~~Updated documentation if necessary~~ (Not applicable.)