### PR TITLE
sort deprecated overloads below non-deprecated ones

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Availability.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Availability/Availability.swift
@@ -59,3 +59,11 @@ extension SymbolGraph.Symbol {
         (mixins[Availability.mixinKey] as? Availability)?.availability
     }
 }
+
+extension UnifiedSymbolGraph.Symbol {
+    public var availability: [UnifiedSymbolGraph.Selector: [SymbolGraph.Symbol.Availability.AvailabilityItem]] {
+        mixins.compactMapValues({ mixins in
+            (mixins[SymbolGraph.Symbol.Availability.mixinKey] as? SymbolGraph.Symbol.Availability)?.availability
+        })
+    }
+}

--- a/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraph+OverloadsTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraph+OverloadsTests.swift
@@ -352,6 +352,228 @@ class UnifiedGraphOverloadsTests: XCTestCase {
             $0.target == iOSOverloadGroupIdentifier || $0.source == iOSOverloadGroupIdentifier
         }))
     }
+
+    /// Ensure that overload groups continue to sort overloads by identifier when both overloads are deprecated.
+    func testDeprecatedOverloads() throws {
+        let unifiedGraph = try unifySymbolGraphs(
+            ("DemoKit.symbols.json", makeSymbolGraph(
+                platform: "macosx",
+                symbols: [
+                    .init(
+                        identifier: .init(precise: "s:myFunc-1", interfaceLanguage: "swift"),
+                        names: .init(title: "myFunc()", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["myFunc()"],
+                        docComment: nil,
+                        accessLevel: .init(rawValue: "public"),
+                        kind: .init(parsedIdentifier: .func, displayName: "Function"),
+                        mixins: [
+                            SymbolGraph.Symbol.Availability.mixinKey:
+                                SymbolGraph.Symbol.Availability(availability: [
+                                    .init(
+                                        domain: .init(rawValue: "macOS"),
+                                        introducedVersion: nil,
+                                        deprecatedVersion: .init(major: 10, minor: 0, patch: 0),
+                                        obsoletedVersion: nil,
+                                        message: "Use myOtherFunc, it's better",
+                                        renamed: nil,
+                                        isUnconditionallyDeprecated: false,
+                                        isUnconditionallyUnavailable: false,
+                                        willEventuallyBeDeprecated: false)
+                                ])
+                        ]),
+                    .init(
+                        identifier: .init(precise: "s:myFunc-2", interfaceLanguage: "swift"),
+                        names: .init(title: "myFunc()", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["myFunc()"],
+                        docComment: nil,
+                        accessLevel: .init(rawValue: "public"),
+                        kind: .init(parsedIdentifier: .func, displayName: "Function"),
+                        mixins: [
+                            SymbolGraph.Symbol.Availability.mixinKey:
+                                SymbolGraph.Symbol.Availability(availability: [
+                                    .init(
+                                        domain: .init(rawValue: "macOS"),
+                                        introducedVersion: nil,
+                                        deprecatedVersion: .init(major: 10, minor: 0, patch: 0),
+                                        obsoletedVersion: nil,
+                                        message: "Use myOtherFunc, it's better",
+                                        renamed: nil,
+                                        isUnconditionallyDeprecated: false,
+                                        isUnconditionallyUnavailable: false,
+                                        willEventuallyBeDeprecated: false)
+                                ])
+                        ]),
+                ],
+                relations: []))
+        )
+
+        let overloadSymbols = [
+            "s:myFunc-1",
+            "s:myFunc-2",
+        ]
+        let expectedOverloadGroupIdentifier = "s:myFunc-1::OverloadGroup"
+
+        let allRelations = unifiedGraph.unifiedRelationships
+
+        // Make sure that overloadOf relationships were added
+        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+        XCTAssertEqual(overloadRelations.count, 2)
+        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+
+        // Pull out the overload group's identifier and make sure that it exists
+        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
+
+        // Make sure that the individual overloads reference the overload group and their index properly
+        for overloadIndex in overloadSymbols.indices {
+            let overloadIdentifier = overloadSymbols[overloadIndex]
+            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+        }
+    }
+
+    /// Ensure that an overload group does not select a deprecated overload as the overload group
+    /// when a non-deprecated overload is available.
+    func testPartiallyDeprecatedOverloads() throws {
+        let unifiedGraph = try unifySymbolGraphs(
+            ("DemoKit.symbols.json", makeSymbolGraph(
+                platform: "macosx",
+                symbols: [
+                    .init(
+                        identifier: .init(precise: "s:myFunc-1", interfaceLanguage: "swift"),
+                        names: .init(title: "myFunc()", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["myFunc()"],
+                        docComment: nil,
+                        accessLevel: .init(rawValue: "public"),
+                        kind: .init(parsedIdentifier: .func, displayName: "Function"),
+                        mixins: [
+                            SymbolGraph.Symbol.Availability.mixinKey:
+                                SymbolGraph.Symbol.Availability(availability: [
+                                    .init(
+                                        domain: .init(rawValue: "macOS"),
+                                        introducedVersion: nil,
+                                        deprecatedVersion: .init(major: 10, minor: 0, patch: 0),
+                                        obsoletedVersion: nil,
+                                        message: "Use the other myFunc, it's better",
+                                        renamed: nil,
+                                        isUnconditionallyDeprecated: false,
+                                        isUnconditionallyUnavailable: false,
+                                        willEventuallyBeDeprecated: false)
+                                ])
+                        ]),
+                    .init(
+                        identifier: .init(precise: "s:myFunc-2", interfaceLanguage: "swift"),
+                        names: .init(title: "myFunc()", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["myFunc()"],
+                        docComment: nil,
+                        accessLevel: .init(rawValue: "public"),
+                        kind: .init(parsedIdentifier: .func, displayName: "Function"),
+                        mixins: [:]),
+                ],
+                relations: []))
+        )
+
+        let overloadSymbols = [
+            "s:myFunc-2",
+            "s:myFunc-1",
+        ]
+        let expectedOverloadGroupIdentifier = "s:myFunc-2::OverloadGroup"
+
+        let allRelations = unifiedGraph.unifiedRelationships
+
+        // Make sure that overloadOf relationships were added
+        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+        XCTAssertEqual(overloadRelations.count, 2)
+        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+
+        // Pull out the overload group's identifier and make sure that it exists
+        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
+
+        // Make sure that the individual overloads reference the overload group and their index properly
+        for overloadIndex in overloadSymbols.indices {
+            let overloadIdentifier = overloadSymbols[overloadIndex]
+            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+        }
+    }
+
+    /// Like the above, but ensure that the same behavior holds for "unconditionally deprecated" symbols.
+    func testPartiallyUnconditionallyDeprecatedOverloads() throws {
+        let unifiedGraph = try unifySymbolGraphs(
+            ("DemoKit.symbols.json", makeSymbolGraph(
+                platform: "macosx",
+                symbols: [
+                    .init(
+                        identifier: .init(precise: "s:myFunc-1", interfaceLanguage: "swift"),
+                        names: .init(title: "myFunc()", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["myFunc()"],
+                        docComment: nil,
+                        accessLevel: .init(rawValue: "public"),
+                        kind: .init(parsedIdentifier: .func, displayName: "Function"),
+                        mixins: [
+                            SymbolGraph.Symbol.Availability.mixinKey:
+                                SymbolGraph.Symbol.Availability(availability: [
+                                    .init(
+                                        domain: .init(rawValue: "macOS"),
+                                        introducedVersion: nil,
+                                        deprecatedVersion: nil,
+                                        obsoletedVersion: nil,
+                                        message: "Use the other myFunc, it's better",
+                                        renamed: nil,
+                                        isUnconditionallyDeprecated: true,
+                                        isUnconditionallyUnavailable: false,
+                                        willEventuallyBeDeprecated: false)
+                                ])
+                        ]),
+                    .init(
+                        identifier: .init(precise: "s:myFunc-2", interfaceLanguage: "swift"),
+                        names: .init(title: "myFunc()", navigator: nil, subHeading: nil, prose: nil),
+                        pathComponents: ["myFunc()"],
+                        docComment: nil,
+                        accessLevel: .init(rawValue: "public"),
+                        kind: .init(parsedIdentifier: .func, displayName: "Function"),
+                        mixins: [:]),
+                ],
+                relations: []))
+        )
+
+        let overloadSymbols = [
+            "s:myFunc-2",
+            "s:myFunc-1",
+        ]
+        let expectedOverloadGroupIdentifier = "s:myFunc-2::OverloadGroup"
+
+        let allRelations = unifiedGraph.unifiedRelationships
+
+        // Make sure that overloadOf relationships were added
+        let overloadRelations = allRelations.filter({ $0.kind == .overloadOf })
+        XCTAssertEqual(overloadRelations.count, 2)
+        XCTAssertEqual(Set(overloadRelations.map(\.target)).count, 1)
+        XCTAssertEqual(Set(overloadRelations.map(\.source)), Set(overloadSymbols))
+
+        // Pull out the overload group's identifier and make sure that it exists
+        let overloadGroupIdentifier = try XCTUnwrap(overloadRelations.first?.target)
+        XCTAssertEqual(overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+        XCTAssert(unifiedGraph.symbols.keys.contains(overloadGroupIdentifier))
+
+        // Make sure that the individual overloads reference the overload group and their index properly
+        for overloadIndex in overloadSymbols.indices {
+            let overloadIdentifier = overloadSymbols[overloadIndex]
+            let overloadSymbol = try XCTUnwrap(unifiedGraph.symbols[overloadIdentifier])
+            let overloadData = try XCTUnwrap(overloadSymbol.unifiedOverloadData)
+            XCTAssertEqual(overloadData.overloadGroupIdentifier, expectedOverloadGroupIdentifier)
+            XCTAssertEqual(overloadData.overloadGroupIndex, overloadIndex)
+        }
+    }
 }
 
 private extension Int {


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://124164488

## Summary

When combining overloaded symbols, we currently display whatever sorts first by declaration (or identifier in the absence of declarations) as the overload group symbol's template. This can create a problem in the end viewer if this symbol happens to be deprecated, since it will now appear as if the overload group as a whole is deprecated. This PR addresses this possibility by adjusting the overloads sorting algorithm to float non-deprecated symbols to the top of the sorted list.

## Dependencies

None

## Testing

Automated testing verifies the new behavior.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary