### PR TITLE
use all selectors, not just "main graph selectors", when collecting overloads-per-selector

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
@@ -21,6 +21,13 @@ extension UnifiedSymbolGraph {
         /// The selector that originated from the "main module" symbol graph, as opposed to an extension.
         public var mainGraphSelectors: [Selector]
 
+        /// All the selectors that this symbol appeared in, regardless of whether it was for a
+        /// "main module" symbol graph or an extension.
+        public var allSelectors: [Selector] {
+            .init(modules.keys)
+        }
+
+        /// The module information where this symbol appears.
         public var modules: [Selector: SymbolGraph.Module]
 
         /// The kind of symbol.

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
@@ -312,8 +312,8 @@ extension UnifiedSymbolGraph {
             // the things we need to check and inspecting the relationships as we go.
 
             /// The overloaded symbols that exist in a given selector.
-            let overloadsPerSelector: [Selector: Set<String>] = overloadedSymbols.reduce(into: [:], { acc, symbol  in
-                for selector in symbol.mainGraphSelectors {
+            let overloadsPerSelector: [Selector: Set<String>] = overloadedSymbols.reduce(into: [:], { acc, symbol in
+                for selector in symbol.allSelectors {
                     acc[selector, default: []].insert(symbol.uniqueIdentifier)
                 }
             })


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://128284906

## Summary

In #72, i introduced a processing step for cross-platform overload groups where those groups were different depending on the symbol graph that they appeared in. However, this implementation had a flaw: When cleaning up relationships to superfluous overload groups, i used the overloads' "main graph selectors" to restrict which lists of relationships to iterate over. This meant that such overload groups that appeared in extension symbol graphs were not properly cleaned up, leading to a crash in Swift-DocC. This PR updates the filter to use a new `allSelectors` property, which allows these extension overloads to be handled correctly.

## Dependencies

None

## Testing

Automated testing verifies the expected behavior.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary