### PR TITLE
use all selectors when collecting overloads-per-selector

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
@@ -21,6 +21,13 @@ extension UnifiedSymbolGraph {
         /// The selector that originated from the "main module" symbol graph, as opposed to an extension.
         public var mainGraphSelectors: [Selector]
 
+        /// All the selectors that this symbol appeared in, regardless of whether it was for a
+        /// "main module" symbol graph or an extension.
+        public var allSelectors: [Selector] {
+            .init(modules.keys)
+        }
+
+        /// The module information where this symbol appears.
         public var modules: [Selector: SymbolGraph.Module]
 
         /// The kind of symbol.

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
@@ -312,8 +312,8 @@ extension UnifiedSymbolGraph {
             // the things we need to check and inspecting the relationships as we go.
 
             /// The overloaded symbols that exist in a given selector.
-            let overloadsPerSelector: [Selector: Set<String>] = overloadedSymbols.reduce(into: [:], { acc, symbol  in
-                for selector in symbol.mainGraphSelectors {
+            let overloadsPerSelector: [Selector: Set<String>] = overloadedSymbols.reduce(into: [:], { acc, symbol in
+                for selector in symbol.allSelectors {
                     acc[selector, default: []].insert(symbol.uniqueIdentifier)
                 }
             })


### PR DESCRIPTION
- **Explanation**: Fixes an optimization that incorrectly used a unified symbol's "main graph selectors" when cleaning up overload groups
- **Scope**: Fixes an inconsistency in overload groups data when overloads were added in extension symbol graphs that differed across platforms.
- **Issue**: rdar://128284906
- **Original PR**: https://github.com/apple/swift-docc-symbolkit/pull/76
- **Risk**: Low. The fix is a targeted change in an optional feature.
- **Testing**: Automated testing has been added to verify the intended behavior.
- **Reviewer**: @patshaughnessy 