### PR TITLE
Add missing public memberwise initializers to 2 public types

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/AlternateDeclarations.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/AlternateDeclarations.swift
@@ -87,6 +87,11 @@ extension SymbolGraph.Symbol {
                 self.docComment = nil
                 self.mixins = [DeclarationFragments.mixinKey: declarationFragments]
             }
+            
+            public init(docComment: SymbolGraph.LineList? = nil, mixins: [String : any Mixin] = [:]) {
+                self.docComment = docComment
+                self.mixins = mixins
+            }
 
             /// Whether this alternate has no information and should be discarded.
             public var isEmpty: Bool {

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Swift/GenericParameter.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Swift/GenericParameter.swift
@@ -47,5 +47,11 @@ extension SymbolGraph.Symbol.Swift {
          `T` has depth 0 and `U` has depth 1.
          */
         public var depth: Int
+        
+        public init(name: String, index: Int, depth: Int) {
+            self.name = name
+            self.index = index
+            self.depth = depth
+        }
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This add public memberwise initializers to `AlternateSymbol` and `GenericParameter`.

## Dependencies

None.

## Testing

Nothing in particular.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary