### PR TITLE
Keep ARM 64 bit based arch as the canonical architecture.

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Platform.swift
+++ b/Sources/SymbolKit/SymbolGraph/Platform.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SymbolKit/SymbolGraph/Platform.swift
+++ b/Sources/SymbolKit/SymbolGraph/Platform.swift
@@ -15,6 +15,9 @@ extension SymbolGraph {
          The name of the architecture that this module targets, such as `x86_64` or `arm64`. If the module doesn't have a specific architecture, this may be undefined.
          */
         public var architecture: String?
+        var isAppleSilicon: Bool {
+            architecture == "aarch64" || architecture == "arm64"
+        }
 
         /**
          The platform vendor from which this module came, such as `apple` or `linux`.

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
@@ -126,6 +126,13 @@ extension UnifiedSymbolGraph {
             if isMainGraph && !self.mainGraphSelectors.contains(selector) {
                 self.mainGraphSelectors.append(selector)
             }
+            // Preserve Apple Silicon symbol information over other architectures.
+            if let existingPlatform = self.modules[selector]?.platform {
+                let incomingPlatform = module.platform
+                if !incomingPlatform.isAppleSilicon && existingPlatform.isAppleSilicon {
+                    return
+                }
+            }
 
             // Add a new variant to the fields that track it
             self.modules[selector] = module

--- a/Tests/SymbolKitTests/UnifiedGraph/UnifiedSymbolTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/UnifiedSymbolTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information

--- a/Tests/SymbolKitTests/UnifiedGraph/UnifiedSymbolTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/UnifiedSymbolTests.swift
@@ -527,5 +527,66 @@ class UnifiedSymbolTests: XCTestCase {
 
         return comboSymbol
     }
+    
+    func testSameSymbolWithDifferentArchitectures() throws {
+        let decoder = JSONDecoder()
+       
+        let aarch64Module = SymbolGraph.Module(name: "TestModule", platform: SymbolGraph.Platform(architecture: "aarch64", vendor: nil, operatingSystem: nil, environment: nil), version: nil, bystanders: nil)
+        let x86_64Module = SymbolGraph.Module(name: "TestModule", platform: SymbolGraph.Platform(architecture: "x86_64", vendor: nil, operatingSystem: nil, environment: nil), version: nil, bystanders: nil)
+
+        let aarch64SymbolLiteral = """
+        {
+           "kind": {
+               "identifier": "swift.class",
+               "displayName": "Class"
+           },
+           "identifier": {
+               "precise": "c:objc(cs)PlayingCard",
+               "interfaceLanguage": "swift"
+           },
+           "pathComponents": [
+               "PlayingCard"
+           ],
+           "names": {
+               "title": "PlayingCard aarch64"
+           },
+           "accessLevel": "open"
+        }
+        """
+        let x86_64SymbolLiteral = """
+        {
+           "kind": {
+               "identifier": "swift.class",
+               "displayName": "Class"
+           },
+           "identifier": {
+               "precise": "c:objc(cs)PlayingCard",
+               "interfaceLanguage": "swift"
+           },
+           "pathComponents": [
+               "PlayingCard"
+           ],
+           "names": {
+               "title": "PlayingCard x86_64"
+           },
+           "accessLevel": "open"
+        }
+        """
+
+        let aarch64Symbol = try decoder.decode(SymbolGraph.Symbol.self, from: Data(aarch64SymbolLiteral.utf8))
+        let x86_64Symbol = try decoder.decode(SymbolGraph.Symbol.self, from: Data(x86_64SymbolLiteral.utf8))
+
+        var unifiedSymbol = UnifiedSymbolGraph.Symbol(fromSingleSymbol: x86_64Symbol, module: x86_64Module, isMainGraph: true)
+        unifiedSymbol.mergeSymbol(symbol: aarch64Symbol, module: aarch64Module, isMainGraph: true)
+        XCTAssertEqual(unifiedSymbol.uniqueIdentifier, "c:objc(cs)PlayingCard")
+        XCTAssertEqual(unifiedSymbol.names[swiftSelector]?.title, "PlayingCard aarch64")
+
+        // Validate that when a symbol exists in both Apple Silicon and another
+        // architecture with different information, the Apple Silicon version prevails.
+        unifiedSymbol = UnifiedSymbolGraph.Symbol(fromSingleSymbol: aarch64Symbol, module: aarch64Module, isMainGraph: true)
+        unifiedSymbol.mergeSymbol(symbol: x86_64Symbol, module: x86_64Module, isMainGraph: true)
+        XCTAssertEqual(unifiedSymbol.uniqueIdentifier, "c:objc(cs)PlayingCard")
+        XCTAssertEqual(unifiedSymbol.names[swiftSelector]?.title, "PlayingCard aarch64")
+    }
 
 }


### PR DESCRIPTION
Bug/issue #, if applicable:  174845543

## Summary

When merging symbols with a shared selector but different architectures,
we overwrite the information of the already recorded symbol. This causes
the latest recorded symbol to prevail, making the result dependent on the
processing order of symbol graphs.

Symbol information can differ across architectures (e.g., availability, declaration
fragments), so for consistency, ARM 64-bit (Apple Silicon) is now the canonical
architecture. This change ensures that when a SGF generated by a 64 bit arch is available,
its symbol information prevails regardless of the order in which architectures are processed.
If there's none, a different version of the symbol remains.
## Dependencies

N/A

## Testing

Unit test added to verify the correct behaviour.

For a more complete test, using swift-docc, preview the following DocC catalog:
[ArchTest.docc.zip](https://github.com/user-attachments/files/27250809/ArchTest.docc.zip)


## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [ ] Updated documentation if necessary (N/A)