### PR TITLE
[6.4.X] Keep ARM 64 bit based arch as the canonical architecture. (#111)

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Platform.swift
+++ b/Sources/SymbolKit/SymbolGraph/Platform.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,9 @@ extension SymbolGraph {
          The name of the architecture that this module targets, such as `x86_64` or `arm64`. If the module doesn't have a specific architecture, this may be undefined.
          */
         public var architecture: String?
+        var isAppleSilicon: Bool {
+            architecture == "aarch64" || architecture == "arm64"
+        }
 
         /**
          The platform vendor from which this module came, such as `apple` or `linux`.

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbol.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -125,6 +125,13 @@ extension UnifiedSymbolGraph {
 
             if isMainGraph && !self.mainGraphSelectors.contains(selector) {
                 self.mainGraphSelectors.append(selector)
+            }
+            // Preserve Apple Silicon symbol information over other architectures.
+            if let existingPlatform = self.modules[selector]?.platform {
+                let incomingPlatform = module.platform
+                if !incomingPlatform.isAppleSilicon && existingPlatform.isAppleSilicon {
+                    return
+                }
             }
 
             // Add a new variant to the fields that track it

--- a/Tests/SymbolKitTests/UnifiedGraph/UnifiedSymbolTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/UnifiedSymbolTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -526,6 +526,67 @@ class UnifiedSymbolTests: XCTestCase {
         comboSymbol.mergeSymbol(symbol: decoded2, module: module, isMainGraph: false)
 
         return comboSymbol
+    }
+    
+    func testSameSymbolWithDifferentArchitectures() throws {
+        let decoder = JSONDecoder()
+       
+        let aarch64Module = SymbolGraph.Module(name: "TestModule", platform: SymbolGraph.Platform(architecture: "aarch64", vendor: nil, operatingSystem: nil, environment: nil), version: nil, bystanders: nil)
+        let x86_64Module = SymbolGraph.Module(name: "TestModule", platform: SymbolGraph.Platform(architecture: "x86_64", vendor: nil, operatingSystem: nil, environment: nil), version: nil, bystanders: nil)
+
+        let aarch64SymbolLiteral = """
+        {
+           "kind": {
+               "identifier": "swift.class",
+               "displayName": "Class"
+           },
+           "identifier": {
+               "precise": "c:objc(cs)PlayingCard",
+               "interfaceLanguage": "swift"
+           },
+           "pathComponents": [
+               "PlayingCard"
+           ],
+           "names": {
+               "title": "PlayingCard aarch64"
+           },
+           "accessLevel": "open"
+        }
+        """
+        let x86_64SymbolLiteral = """
+        {
+           "kind": {
+               "identifier": "swift.class",
+               "displayName": "Class"
+           },
+           "identifier": {
+               "precise": "c:objc(cs)PlayingCard",
+               "interfaceLanguage": "swift"
+           },
+           "pathComponents": [
+               "PlayingCard"
+           ],
+           "names": {
+               "title": "PlayingCard x86_64"
+           },
+           "accessLevel": "open"
+        }
+        """
+
+        let aarch64Symbol = try decoder.decode(SymbolGraph.Symbol.self, from: Data(aarch64SymbolLiteral.utf8))
+        let x86_64Symbol = try decoder.decode(SymbolGraph.Symbol.self, from: Data(x86_64SymbolLiteral.utf8))
+
+        var unifiedSymbol = UnifiedSymbolGraph.Symbol(fromSingleSymbol: x86_64Symbol, module: x86_64Module, isMainGraph: true)
+        unifiedSymbol.mergeSymbol(symbol: aarch64Symbol, module: aarch64Module, isMainGraph: true)
+        XCTAssertEqual(unifiedSymbol.uniqueIdentifier, "c:objc(cs)PlayingCard")
+        XCTAssertEqual(unifiedSymbol.names[swiftSelector]?.title, "PlayingCard aarch64")
+
+        // Validate that when a symbol exists in both Apple Silicon and another
+        // architecture with different information, the Apple Silicon version prevails.
+        unifiedSymbol = UnifiedSymbolGraph.Symbol(fromSingleSymbol: aarch64Symbol, module: aarch64Module, isMainGraph: true)
+        unifiedSymbol.mergeSymbol(symbol: x86_64Symbol, module: x86_64Module, isMainGraph: true)
+        XCTAssertEqual(unifiedSymbol.uniqueIdentifier, "c:objc(cs)PlayingCard")
+        XCTAssertEqual(unifiedSymbol.names[swiftSelector]?.title, "PlayingCard aarch64")
     }
 
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 174845543

**Explanation:** Removes non deterministic behavior by keeping ARM 64-bit based arch (Apple silicon) as the canonical architecture for symbol information.
**Scope:** Deterministic declaration fragments and availability in DocC output.
**Original PR:** https://github.com/swiftlang/swift-docc-symbolkit/pull/111
**Risk:** Medium. The Intel based information of the symbols will be discarded if there's an Apple silicon version.
**Testing:** New automated tests demonstrate the new behaviour. End2end tests with a dummy SGF.
**Reviewer:** @QuietMisdreavus 