### PR TITLE
Deterministically merge relationships in unified graph

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -102,7 +102,7 @@ extension GraphCollector {
     public func finishLoading(
         createOverloadGroups: Bool = false
     ) -> (unifiedGraphs: [String: UnifiedSymbolGraph], graphSources: [String: [GraphKind]]) {
-        for (url, graph) in self.extensionGraphs {
+        for (url, graph) in self.extensionGraphs.sorted(by: { $0.key.absoluteString < $1.key.absoluteString }) {
             self.mergeSymbolGraph(graph, at: url, forceLoading: true)
         }
 

--- a/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/UnifiedSymbolGraph.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2021-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -117,7 +117,8 @@ extension UnifiedSymbolGraph {
 
     /// Merge the given lists of ``SymbolGraph/Relationship``s.
     ///
-    /// This function will deduplicate relationships based on their source, target, and kind. If it sees a duplicate, it will keep the first one it sees.
+    /// This function keys relationships by their source, target, and kind.
+    /// Deduplication is done using ``preferredRelationship(first:second:)``.
     func mergeRelationships(_ relationsList: [SymbolGraph.Relationship]...)
     -> [SymbolGraph.Relationship] {
         struct RelationKey: Hashable {
@@ -130,19 +131,39 @@ extension UnifiedSymbolGraph {
                 self.target = relationship.target
                 self.kind = relationship.kind
             }
-
-            static func makePair(fromRelation relationship: SymbolGraph.Relationship) -> (RelationKey, SymbolGraph.Relationship) {
-                return (RelationKey(fromRelation: relationship), relationship)
-            }
         }
 
         let allRelations = relationsList.joined()
 
-        // deduplicate the combined relationships array by source/target/kind
+        // Deduplicate relationships using ``preferredRelationship(first:second:)``.
         // FIXME: Actually merge relationships if they have different mixins (rdar://84267943)
-        let map = [:].merging(allRelations.map({ RelationKey.makePair(fromRelation: $0) }), uniquingKeysWith: { r1, r2 in r1 })
+        var deduplicated: [RelationKey: SymbolGraph.Relationship] = [:]
+        var orderedKeys: [RelationKey] = []
+        for relationship in allRelations {
+            let key = RelationKey(fromRelation: relationship)
+            if let existing = deduplicated[key] {
+                deduplicated[key] = preferredRelationship(existing, relationship)
+            } else {
+                deduplicated[key] = relationship
+                orderedKeys.append(key)
+            }
+        }
+        return orderedKeys.map { deduplicated[$0]! }
+    }
 
-        return Array(map.values)
+    /// A comparator for relationships that share a source, target, and kind.
+    /// The presence of ``SymbolGraph/Relationship/targetFallback`` is preferred.
+    /// When both symbols have a target fallback, they are compared lexicographically.
+    private func preferredRelationship(
+        _ first: SymbolGraph.Relationship,
+        _ second: SymbolGraph.Relationship
+    ) -> SymbolGraph.Relationship {
+        switch (first.targetFallback, second.targetFallback) {
+            case (_?, nil), (nil, nil): first
+            case (nil, _?):        second
+            case let (lhs?, rhs?):
+                lhs <= rhs ? first : second
+        }
     }
 
     /// Scans over ``orphanRelationships`` and sorts any whose source/target symbols were loaded

--- a/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraphTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/UnifiedGraphTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2024 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -133,6 +133,41 @@ class UnifiedGraphTests: XCTestCase {
         let extensionSym = try XCTUnwrap(demoGraph.symbols["s:SomeStruct"])
         let extensionSymModule = try XCTUnwrap(extensionSym.modules[.init(forSymbolGraph: extensionSyms)!])
         XCTAssertEqual(extensionSymModule.name, "OtherKit")
+    }
+
+    func testMergeRelationshipsDeduplicatesWithTargetFallback() throws {
+        let graph = try XCTUnwrap(UnifiedSymbolGraph(
+            fromSingleGraph: makeSymbolGraph(symbols: [], relations: []),
+            at: .init(fileURLWithPath: "Example.symbols.json")))
+
+        let symbol = SymbolGraph.Relationship(
+            source: "s:SomeType", target: "s:SomeProtocol", kind: .conformsTo, targetFallback: "OtherModule.SomeProtocol")
+        let duplicate = SymbolGraph.Relationship(
+            source: "s:SomeType", target: "s:SomeProtocol", kind: .conformsTo, targetFallback: "SomeProtocol")
+
+        let forward = graph.mergeRelationships([symbol], [duplicate])
+        let backward = graph.mergeRelationships([duplicate], [symbol])
+
+        XCTAssertEqual(forward.count, 1)
+        XCTAssertEqual(backward.count, 1)
+        XCTAssertEqual(forward, backward, "Deduplication must not depend on merge order")
+        XCTAssertEqual(forward.first?.targetFallback, "OtherModule.SomeProtocol", "The deduplicated symbol should have the lexicographically smallest target fallback")
+    }
+
+    func testMergeRelationshipsPreservesFirstSeenOrder() throws {
+        let graph = try XCTUnwrap(UnifiedSymbolGraph(
+            fromSingleGraph: makeSymbolGraph(symbols: [], relations: []),
+            at: .init(fileURLWithPath: "Example.symbols.json")))
+
+        let left = ["s:A", "s:B", "s:A"].map {
+            SymbolGraph.Relationship(source: "s:SomeType", target: $0, kind: .conformsTo, targetFallback: nil)
+        }
+        let right = ["s:C", "s:B", "s:C"].map {
+            SymbolGraph.Relationship(source: "s:SomeType", target: $0, kind: .conformsTo, targetFallback: nil)
+        }
+
+        let merged = graph.mergeRelationships(left, right)
+        XCTAssertEqual(merged.map(\.target), ["s:A", "s:B", "s:C"])
     }
 }
 


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://183034556

## Summary

`mergeRelationships` returns an `Array(map.values)`, whose ordering is not stable. The deduplication also operates on a first-seen basis, leading to cases where duplicate relationships with different target fallbacks are non-deterministically chosen to be retained.

Deduplicate using the target fallback instead, and use the first-seen order to ensure that the merge output is stable. Also sort the extension graphs lexicographically by path to ensure that the merge input is stable.

## Dependencies

N/A

## Testing

1. Create two symbol graphs with duplicate relationships (same source, target, kind) but different target fallbacks.
2. Attempt to merge the relationships with `mergeRelationships(:)` multiple times.
3. Previously, the output would change across runs. With this patch, it remains consistent.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [x] Updated documentation if necessary