### PR TITLE
Fix `moduleNameFor` logic for cross-import overlays.

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -139,7 +139,11 @@ extension GraphCollector {
         let isMainSymbolGraph = !url.lastPathComponent.contains("@") && !graph.module.isVirtual
 
         let moduleName: String
-        if isMainSymbolGraph && graph.module.bystanders == nil {
+
+        // FIXME: Stop forcing cross-import overlays into this branch when Swift-DocC corrects its rendering behavior
+        // (https://github.com/swiftlang/swift-docc/issues/1611)
+        let isCrossImportOverlay = graph.module.bystanders != nil
+        if isMainSymbolGraph || isCrossImportOverlay {
             // When bystander modules are present, the symbol graph is a cross-import overlay, and
             // we need to preserve the original module name to properly render it. It is still
             // kept with the extension symbols, due to the merging behavior of UnifiedSymbolGraph.

--- a/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2022-2026 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -183,8 +183,9 @@ class GraphCollectorTests: XCTestCase {
         }
         let a_At_B = try JSONDecoder().decode(SymbolGraph.self, from: jsonDataAatB)
 
-        let (extendedB, extendedBIsMain) = GraphCollector.moduleNameFor(a_At_B, at: .init(fileURLWithPath: "_A_B@B.symbols.json"))
-        XCTAssertFalse(extendedBIsMain)
-        XCTAssertEqual("B", extendedB)
+        // For cross-import overlays the name comes from the graph's `module.name`, not from the module named after the "@" in the file name.
+        let (overlayAtBName, overlayAtBIsMain) = GraphCollector.moduleNameFor(a_At_B, at: .init(fileURLWithPath: "_A_B@B.symbols.json"))
+        XCTAssertFalse(overlayAtBIsMain)
+        XCTAssertEqual("A", overlayAtBName)
     }
 }


### PR DESCRIPTION
Bug/issue #, if applicable:  rdar://183708988

## Summary

The method `moduleNameFor`[1] returns the name of the module given a Symbol Graph (SG) and the
SG URL, along with whether it's a main SG. Part of the logic of this method detects when the SG is a cross-import overlay [2].

A comment in this method states that when bystanders are present the SG is a cross-import
overlay [3], but that specific piece of logic is only executed if the `graph.module.bystanders`
property is `nil`, so it never applies to overlays.

That condition was introduced deliberately in [5], on the grounds that `_A_B@B.symbols.json` holds
symbols that extend `B`. For cross-import overlays that is wrong. `_A_B@B.symbols.json` contains symbols 
that extend `A`.

DocC did not hit this error until now because it kept its own copy of this logic. That copy was removed in [4].

This code change fixes the logic so if the SG is coming from an overlay, the module name comes from the SG data `module.name`.

This matches the (now removed) DocC implementation of this method [4].

This commit also updates the test so it matches the expected behaviors.

rdar://183708988

---

[1] https://github.com/swiftlang/swift-docc-symbolkit/blob/main/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift#L134
[2] https://forums.swift.org/t/cross-import-overlays/36710
[3] https://github.com/swiftlang/swift-docc-symbolkit/blob/main/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift#L143
[4] https://github.com/swiftlang/swift-docc/commit/b577c7220a6c7f10b2b7c7fcb98457ebf92a3921
[5] https://github.com/swiftlang/swift-docc-symbolkit/commit/3fc0c6880f712ce38137d0752f24b568fce1522e

## Dependencies

N/A

## Testing

N/A

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran the `./bin/test` script and it succeeded
- [X] Updated documentation if necessary