### PR TITLE
Revert "Fix `moduleNameFor` logic for cross-import overlays."

### DIFF
--- a/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
+++ b/Sources/SymbolKit/UnifiedSymbolGraph/GraphCollector.swift
@@ -139,11 +139,7 @@ extension GraphCollector {
         let isMainSymbolGraph = !url.lastPathComponent.contains("@") && !graph.module.isVirtual
 
         let moduleName: String
-
-        // FIXME: Stop forcing cross-import overlays into this branch when Swift-DocC corrects its rendering behavior
-        // (https://github.com/swiftlang/swift-docc/issues/1611)
-        let isCrossImportOverlay = graph.module.bystanders != nil
-        if isMainSymbolGraph || isCrossImportOverlay {
+        if isMainSymbolGraph && graph.module.bystanders == nil {
             // When bystander modules are present, the symbol graph is a cross-import overlay, and
             // we need to preserve the original module name to properly render it. It is still
             // kept with the extension symbols, due to the merging behavior of UnifiedSymbolGraph.

--- a/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
+++ b/Tests/SymbolKitTests/UnifiedGraph/GraphCollectorTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2022-2026 Apple Inc. and the Swift project authors
+ Copyright (c) 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See https://swift.org/LICENSE.txt for license information
@@ -183,9 +183,8 @@ class GraphCollectorTests: XCTestCase {
         }
         let a_At_B = try JSONDecoder().decode(SymbolGraph.self, from: jsonDataAatB)
 
-        // For cross-import overlays the name comes from the graph's `module.name`, not from the module named after the "@" in the file name.
-        let (overlayAtBName, overlayAtBIsMain) = GraphCollector.moduleNameFor(a_At_B, at: .init(fileURLWithPath: "_A_B@B.symbols.json"))
-        XCTAssertFalse(overlayAtBIsMain)
-        XCTAssertEqual("A", overlayAtBName)
+        let (extendedB, extendedBIsMain) = GraphCollector.moduleNameFor(a_At_B, at: .init(fileURLWithPath: "_A_B@B.symbols.json"))
+        XCTAssertFalse(extendedBIsMain)
+        XCTAssertEqual("B", extendedB)
     }
 }


### PR DESCRIPTION
Reverts swiftlang/swift-docc-symbolkit#114

It looks like this change broke a test in DocC. See https://github.com/swiftlang/swift-docc/pull/1614 for the details.

I'm going to revert this for now so we can investigate what went wrong.