### PR TITLE
Clarify the documentation for the `prose` symbol name

### DIFF
--- a/Sources/SymbolKit/SymbolGraph/Symbol/Names.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Names.swift
@@ -31,7 +31,7 @@ extension SymbolGraph.Symbol {
         public var subHeading: [DeclarationFragments.Fragment]?
 
         /**
-         A name to use in documentation prose or inline link titles.
+         The name of a symbol when referred to inline in documentation prose, such as the text of an inline link to the symbol.
 
          > Note: If undefined, use the `title`.
          */

--- a/Sources/SymbolKit/SymbolGraph/Symbol/Names.swift
+++ b/Sources/SymbolKit/SymbolGraph/Symbol/Names.swift
@@ -31,7 +31,7 @@ extension SymbolGraph.Symbol {
         public var subHeading: [DeclarationFragments.Fragment]?
 
         /**
-         The name of a symbol when referred to inline in documentation prose, such as the text of an inline link to the symbol.
+         An abbreviated form of the symbol's title that's preferred for use in documentation prose and inline link text.
 
          > Note: If undefined, use the `title`.
          */

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -263,7 +263,7 @@ components:
               items:
                 $ref: "#/components/schemas/DeclarationFragment"
             prose:
-              description: The name of a symbol when shown inline with other prose.
+              description: The name of a symbol when referred to inline in documentation prose, such as the text of an inline link to the symbol. If absent, `title` is used instead.
               type: string
               nullable: true
         docComment:


### PR DESCRIPTION
Bug/issue #, if applicable: None

## Summary

Swift-DocC now consumes this field: swiftlang/swift-docc#1557 uses `names.prose` as the link text for inline symbol links, falling back to `names.title` when it's absent.

Describe that inline-link use, and state the fallback to `title` in the OpenAPI schema.

## Dependencies

None

## Testing

N/A

## Checklist

- [ ] Added tests - N/A
- [ ] Ran the `./bin/test` script and it succeeded - N/A
- [x] Updated documentation if necessary